### PR TITLE
Fix: Pass request context to ShowcaseFlatSerializer

### DIFF
--- a/case_studies/closecycle/serializers.py
+++ b/case_studies/closecycle/serializers.py
@@ -63,9 +63,11 @@ class ShowcaseSummaryListSerializer(ModelSerializer):
         fields = ['summaries']
 
     def to_representation(self, data):
+        # Get the context from the parent serializer
+        context = self.context 
         if isinstance(data, list):
-            return {'summaries': [ShowcaseFlatSerializer(instance).data for instance in data]}
-        return {'summaries': [ShowcaseFlatSerializer(data).data]}
+            return {'summaries': [ShowcaseFlatSerializer(instance, context=context).data for instance in data]}
+        return {'summaries': [ShowcaseFlatSerializer(data, context=context).data]}
 
 
 class ShowcaseGeoFeatureModelSerializer(BaseGeoFeatureModelSerializer):


### PR DESCRIPTION
Resolves an AttributeError where ShowcaseFlatSerializer attempted to access self.request, but it was not available.

The ShowcaseSummaryListSerializer was not passing its context when instantiating ShowcaseFlatSerializer within its to_representation method. This commit updates ShowcaseSummaryListSerializer to correctly propagate the request context.