### PR TITLE
Fix NullableRangeFilter null-only range

### DIFF
--- a/utils/filters.py
+++ b/utils/filters.py
@@ -65,15 +65,17 @@ class NullableRangeFilter(RangeFilter):
             QuerySet: The filtered queryset.
         """
         if not range_with_null_flag:
-            return super().filter(queryset, range_with_null_flag)
+            return queryset
         value_range, is_null = range_with_null_flag
         isnull_lookup = f"{self.field_name}__isnull"
+
+        if value_range.start is None and value_range.stop is None:
+            return queryset.filter(**{isnull_lookup: True}) if is_null else queryset
+
+        filtered_qs = super().filter(queryset, value_range)
         if is_null:
-            return (
-                super().filter(queryset, value_range)
-                | queryset.filter(**{isnull_lookup: True})
-            ).distinct()
-        return super().filter(queryset, value_range)
+            return (filtered_qs | queryset.filter(**{isnull_lookup: True})).distinct()
+        return filtered_qs
 
 
 class NullablePercentageRangeFilter(NullableRangeFilter):

--- a/utils/tests/test_filters.py
+++ b/utils/tests/test_filters.py
@@ -63,6 +63,20 @@ class TestNullableRangeFilter(TestCase):
         expected = DummyModel.objects.filter(id__in=[self.fifty.id, self.hundred.id])
         self.assertQuerySetEqual(result, expected, ordered=False)
 
+    def test_filter_null_only(self):
+        range_with_null_flag = (slice(None, None), True)
+        filter_ = NullableRangeFilter(field_name="test_field")
+        result = filter_.filter(DummyModel.objects.all(), range_with_null_flag)
+        expected = DummyModel.objects.filter(test_field__isnull=True)
+        self.assertQuerySetEqual(result, expected, ordered=False)
+
+    def test_filter_no_range_no_null(self):
+        range_with_null_flag = (slice(None, None), False)
+        filter_ = NullableRangeFilter(field_name="test_field")
+        result = filter_.filter(DummyModel.objects.all(), range_with_null_flag)
+        expected = DummyModel.objects.all()
+        self.assertQuerySetEqual(result, expected, ordered=False)
+
 
 class NullablePercentageRangeFilterTestCase(TestCase):
 
@@ -85,4 +99,18 @@ class NullablePercentageRangeFilterTestCase(TestCase):
         filter_ = NullablePercentageRangeFilter(field_name="test_field")
         result = filter_.filter(DummyModel.objects.all(), range_with_null_flag)
         expected = DummyModel.objects.filter(id__in=[self.fifty.id, self.hundred.id])
+        self.assertQuerySetEqual(result, expected, ordered=False)
+
+    def test_filter_null_only(self):
+        range_with_null_flag = (slice(None, None), True)
+        filter_ = NullablePercentageRangeFilter(field_name="test_field")
+        result = filter_.filter(DummyModel.objects.all(), range_with_null_flag)
+        expected = DummyModel.objects.filter(test_field__isnull=True)
+        self.assertQuerySetEqual(result, expected, ordered=False)
+
+    def test_filter_no_range_no_null(self):
+        range_with_null_flag = (slice(None, None), False)
+        filter_ = NullablePercentageRangeFilter(field_name="test_field")
+        result = filter_.filter(DummyModel.objects.all(), range_with_null_flag)
+        expected = DummyModel.objects.all()
         self.assertQuerySetEqual(result, expected, ordered=False)


### PR DESCRIPTION
## Summary
- handle empty range in `NullableRangeFilter`
- test filtering by null only

## Testing
- `pytest -q` *(fails: AppRegistryNotReady: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_6864f6e09d488331aac265385ded8880