### PR TITLE
Fix owner init when username unset

### DIFF
--- a/utils/object_management/utils.py
+++ b/utils/object_management/utils.py
@@ -19,6 +19,11 @@ def ensure_initial_data(stdout=None):
     admin_username = os.environ.get("ADMIN_USERNAME")
     owner_username = getattr(settings, "DEFAULT_OBJECT_OWNER_USERNAME", admin_username)
 
+    if not owner_username:
+        raise RuntimeError(
+            "Neither DEFAULT_OBJECT_OWNER_USERNAME in settings nor ADMIN_USERNAME env var is set."
+        )
+
     try:
         default_owner = User.objects.get(username=owner_username)
     except User.DoesNotExist:

--- a/utils/tests/test_object_management_utils.py
+++ b/utils/tests/test_object_management_utils.py
@@ -1,0 +1,14 @@
+import os
+from unittest import mock
+from django.test import TestCase, override_settings
+
+from utils.object_management import utils as obj_utils
+
+
+class ObjectManagementInitialDataTests(TestCase):
+    def test_missing_env_variables_raises_runtime_error(self):
+        """ensure_initial_data should fail if no usernames are configured."""
+        with override_settings(DEFAULT_OBJECT_OWNER_USERNAME=None):
+            with mock.patch.dict(os.environ, {}, clear=True):
+                with self.assertRaises(RuntimeError):
+                    obj_utils.ensure_initial_data()


### PR DESCRIPTION
## Summary
- guard against missing default owner username
- test `ensure_initial_data` error on unset usernames

## Testing
- `pip install -q -r requirements.txt`
- `apt-get install -y gdal-bin`
- `python manage.py test utils.tests.test_object_management_utils.ObjectManagementInitialDataTests.test_missing_env_variables_raises_runtime_error -v 2` *(fails: TypeError: can only concatenate str (not "NoneType") to str)*

------
https://chatgpt.com/codex/tasks/task_e_686680239c78833182316aa2a9f830f0