### PR TITLE
Fail closed when collection chain filtering errors

### DIFF
--- a/sources/waste_collection/tests/test_views.py
+++ b/sources/waste_collection/tests/test_views.py
@@ -785,6 +785,32 @@ class CollectionPropertyValueCRUDViewsTestCase(
             {predecessor.pk, self.related_objects["collection"].pk},
         )
 
+    def test_detail_context_hides_related_collections_when_visibility_filter_errors(self):
+        predecessor = Collection.objects.create(
+            owner=self.owner_user,
+            name="CPV predecessor hidden on filter error",
+            publication_status="published",
+            valid_from=date(2020, 1, 1),
+        )
+        self.related_objects["collection"].predecessors.add(predecessor)
+
+        self.client.force_login(self.owner_user)
+        with (
+            patch(
+                "sources.waste_collection.views.filter_queryset_for_user",
+                side_effect=RuntimeError("boom"),
+            ),
+            self.assertLogs("sources.waste_collection.views", level="ERROR") as logs,
+        ):
+            response = self.client.get(self.get_detail_url(self.published_object.pk))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["visible_related_collections"], [])
+        self.assertIn(
+            "Failed to filter visible collection chain",
+            "\n".join(logs.output),
+        )
+
 
 # ----------- AggregatedCollectionPropertyValue CRUD -------------------------------------------------------------------
 # ----------------------------------------------------------------------------------------------------------------------

--- a/sources/waste_collection/views.py
+++ b/sources/waste_collection/views.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import logging
 from datetime import date, timedelta
 from urllib.parse import urlencode
 
@@ -126,6 +127,9 @@ from utils.object_management.views import (
 from utils.views import BreadcrumbContextMixin
 
 
+logger = logging.getLogger(__name__)
+
+
 def _visible_collection_chain_for_user(collection, user):
     """Return visible collections from the version chain for ``collection``."""
 
@@ -139,7 +143,12 @@ def _visible_collection_chain_for_user(collection, user):
     try:
         related_qs = filter_queryset_for_user(related_qs, user)
     except Exception:
-        pass
+        logger.exception(
+            "Failed to filter visible collection chain for collection_id=%s and user_id=%s",
+            getattr(collection, "pk", None),
+            getattr(user, "pk", None),
+        )
+        return []
 
     return list(related_qs)
 


### PR DESCRIPTION
Superseded by current `main`: Devin verified the fail-closed visible collection-chain behavior and regression test are already present in `main` (`views.py` / `test_views.py`). Closing before branch cleanup.