### PR TITLE
Log waste collection signal wiring failures

### DIFF
--- a/sources/waste_collection/apps.py
+++ b/sources/waste_collection/apps.py
@@ -1,4 +1,10 @@
+import logging
+from importlib import import_module
+
 from django.apps import AppConfig
+
+
+logger = logging.getLogger(__name__)
 
 
 class WasteCollectionConfig(AppConfig):
@@ -7,14 +13,12 @@ class WasteCollectionConfig(AppConfig):
     verbose_name = "Sources / Waste Collection"
 
     def ready(self):
-        signal_module = None
         try:
-            from . import signals as signal_module
+            signal_module = import_module("sources.waste_collection.signals")
         except Exception:
-            pass
-
-        if signal_module is None:
+            logger.exception("Failed to import waste_collection signal handlers.")
             return
+
         try:
             from django.db.models.signals import post_delete, post_save
 
@@ -30,4 +34,6 @@ class WasteCollectionConfig(AppConfig):
                 dispatch_uid="waste_collection.sync_derived_cpv_on_delete",
             )
         except LookupError:
-            pass
+            logger.warning(
+                "Waste collection signal registration skipped because CollectionPropertyValue could not be resolved."
+            )

--- a/sources/waste_collection/tests/test_apps.py
+++ b/sources/waste_collection/tests/test_apps.py
@@ -1,0 +1,84 @@
+from importlib import import_module
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from sources.waste_collection.apps import WasteCollectionConfig
+
+
+class WasteCollectionConfigReadyTests(SimpleTestCase):
+    def setUp(self):
+        app_module = import_module("sources.waste_collection")
+        self.app_config = WasteCollectionConfig("sources.waste_collection", app_module)
+
+    def test_ready_logs_and_returns_when_signal_import_fails(self):
+        with (
+            patch(
+                "sources.waste_collection.apps.import_module",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch("sources.waste_collection.apps.logger") as logger,
+        ):
+            self.app_config.ready()
+
+        logger.exception.assert_called_once_with(
+            "Failed to import waste_collection signal handlers."
+        )
+
+    def test_ready_connects_collection_property_value_signal_handlers(self):
+        signal_module = SimpleNamespace(
+            sync_derived_cpv_on_save=object(),
+            sync_derived_cpv_on_delete=object(),
+        )
+        collection_property_value_model = object()
+
+        with (
+            patch(
+                "sources.waste_collection.apps.import_module",
+                return_value=signal_module,
+            ),
+            patch.object(
+                self.app_config,
+                "get_model",
+                return_value=collection_property_value_model,
+            ),
+            patch("django.db.models.signals.post_save.connect") as post_save_connect,
+            patch("django.db.models.signals.post_delete.connect") as post_delete_connect,
+        ):
+            self.app_config.ready()
+
+        post_save_connect.assert_called_once_with(
+            signal_module.sync_derived_cpv_on_save,
+            sender=collection_property_value_model,
+            dispatch_uid="waste_collection.sync_derived_cpv_on_save",
+        )
+        post_delete_connect.assert_called_once_with(
+            signal_module.sync_derived_cpv_on_delete,
+            sender=collection_property_value_model,
+            dispatch_uid="waste_collection.sync_derived_cpv_on_delete",
+        )
+
+    def test_ready_logs_lookup_errors_when_model_resolution_fails(self):
+        signal_module = SimpleNamespace(
+            sync_derived_cpv_on_save=object(),
+            sync_derived_cpv_on_delete=object(),
+        )
+
+        with (
+            patch(
+                "sources.waste_collection.apps.import_module",
+                return_value=signal_module,
+            ),
+            patch.object(
+                self.app_config,
+                "get_model",
+                side_effect=LookupError("missing model"),
+            ),
+            patch("sources.waste_collection.apps.logger") as logger,
+        ):
+            self.app_config.ready()
+
+        logger.warning.assert_called_once_with(
+            "Waste collection signal registration skipped because CollectionPropertyValue could not be resolved."
+        )


### PR DESCRIPTION
Superseded by current `main`: Devin verified the signal import / model-resolution logging and focused `test_apps.py` coverage are already present in `main`. Closing before branch cleanup.