### PR TITLE
Generate Catalonia atlas view variants declaratively

### DIFF
--- a/sources/waste_collection/tests/test_views.py
+++ b/sources/waste_collection/tests/test_views.py
@@ -4100,6 +4100,28 @@ class WasteAtlasMapViewsTestCase(TestCase):
                 self.assertNotContains(response, "nutsLevel:")
                 self.assertContains(response, "Map overview")
 
+    def test_catalonia_generated_views_reuse_germany_metadata(self):
+        from sources.waste_collection.waste_atlas import views as atlas_views
+
+        self.assertEqual(
+            atlas_views.CataloniaResidualRequiredBinCapacityMapView.template_name,
+            atlas_views.GermanyResidualRequiredBinCapacityMapView.template_name,
+        )
+        self.assertEqual(
+            atlas_views.CataloniaResidualRequiredBinCapacityMapView.map_title,
+            atlas_views.GermanyResidualRequiredBinCapacityMapView.map_title,
+        )
+        self.assertEqual(
+            atlas_views.CataloniaResidualRequiredBinCapacityMapView.map_route_key,
+            atlas_views.GermanyResidualRequiredBinCapacityMapView.map_route_key,
+        )
+        self.assertTrue(
+            issubclass(
+                atlas_views.CataloniaResidualRequiredBinCapacityMapView,
+                atlas_views.CataloniaAtlasMapView,
+            )
+        )
+
     def test_italy_orga_level_map_ignores_country_and_nuts_query_overrides(self):
         response = self.client.get(
             reverse("waste-atlas-orga-level-italy-map"),

--- a/sources/waste_collection/waste_atlas/views.py
+++ b/sources/waste_collection/waste_atlas/views.py
@@ -1319,158 +1319,73 @@ class GermanyBWRPResidualRequiredBinCapacityMapView(GermanyBWRPAtlasMapView):
     map_route_key = "residual_required_bin_capacity"
 
 
-class CataloniaOrgaLevelMapView(CataloniaAtlasMapView, GermanyOrgaLevelMapView):
-    pass
+def _build_country_variant_map_view(name, atlas_base_class, inherited_view_class):
+    """Create a trivial country-specific atlas view from shared metadata."""
+
+    return type(
+        name,
+        (atlas_base_class, inherited_view_class),
+        {
+            "__module__": __name__,
+            "template_name": inherited_view_class.template_name,
+            "map_title": inherited_view_class.map_title,
+            "map_route_key": inherited_view_class.map_route_key,
+        },
+    )
 
 
-class CataloniaGreenWasteCollectionSystemCountMapView(
-    CataloniaAtlasMapView, GermanyGreenWasteCollectionSystemCountMapView
-):
-    pass
+CATALONIA_GERMANY_VARIANT_VIEWS = (
+    ("CataloniaOrgaLevelMapView", GermanyOrgaLevelMapView),
+    (
+        "CataloniaGreenWasteCollectionSystemCountMapView",
+        GermanyGreenWasteCollectionSystemCountMapView,
+    ),
+    ("CataloniaCollectionPointCountMapView", GermanyCollectionPointCountMapView),
+    ("CataloniaConnectionRateMapView", GermanyConnectionRateMapView),
+    ("CataloniaFoodWasteCategoryMapView", GermanyFoodWasteCategoryMapView),
+    ("CataloniaPaperBagsMapView", GermanyPaperBagsMapView),
+    ("CataloniaPlasticBagsMapView", GermanyPlasticBagsMapView),
+    ("CataloniaCollectionSupportMapView", GermanyCollectionSupportMapView),
+    ("CataloniaResidualFrequencyMapView", GermanyResidualFrequencyMapView),
+    ("CataloniaBiowasteFrequencyMapView", GermanyBiowasteFrequencyMapView),
+    ("CataloniaCombinedFrequencyMapView", GermanyCombinedFrequencyMapView),
+    ("CataloniaResidualCollectionCountMapView", GermanyResidualCollectionCountMapView),
+    ("CataloniaBiowasteCollectionCountMapView", GermanyBiowasteCollectionCountMapView),
+    ("CataloniaCombinedCollectionCountMapView", GermanyCombinedCollectionCountMapView),
+    ("CataloniaCollectionCountRatioMapView", GermanyCollectionCountRatioMapView),
+    ("CataloniaResidualFeeSystemMapView", GermanyResidualFeeSystemMapView),
+    ("CataloniaBiowasteFeeSystemMapView", GermanyBiowasteFeeSystemMapView),
+    ("CataloniaCombinedFeeSystemMapView", GermanyCombinedFeeSystemMapView),
+    ("CataloniaResidualCollectionAmountMapView", GermanyResidualCollectionAmountMapView),
+    ("CataloniaBiowasteCollectionAmountMapView", GermanyBiowasteCollectionAmountMapView),
+    (
+        "CataloniaGreenWasteCollectionAmountMapView",
+        GermanyGreenWasteCollectionAmountMapView,
+    ),
+    ("CataloniaOrganicCollectionAmountMapView", GermanyOrganicCollectionAmountMapView),
+    ("CataloniaOrganicWasteRatioMapView", GermanyOrganicWasteRatioMapView),
+    ("CataloniaBiowasteMinBinSizeMapView", GermanyBiowasteMinBinSizeMapView),
+    ("CataloniaResidualMinBinSizeMapView", GermanyResidualMinBinSizeMapView),
+    (
+        "CataloniaBiowasteRequiredBinCapacityMapView",
+        GermanyBiowasteRequiredBinCapacityMapView,
+    ),
+    (
+        "CataloniaResidualRequiredBinCapacityMapView",
+        GermanyResidualRequiredBinCapacityMapView,
+    ),
+)
 
-
-class CataloniaCollectionPointCountMapView(
-    CataloniaAtlasMapView, GermanyCollectionPointCountMapView
-):
-    pass
-
-
-class CataloniaConnectionRateMapView(CataloniaAtlasMapView, GermanyConnectionRateMapView):
-    pass
-
-
-class CataloniaFoodWasteCategoryMapView(
-    CataloniaAtlasMapView, GermanyFoodWasteCategoryMapView
-):
-    pass
-
-
-class CataloniaPaperBagsMapView(CataloniaAtlasMapView, GermanyPaperBagsMapView):
-    pass
-
-
-class CataloniaPlasticBagsMapView(CataloniaAtlasMapView, GermanyPlasticBagsMapView):
-    pass
-
-
-class CataloniaCollectionSupportMapView(
-    CataloniaAtlasMapView, GermanyCollectionSupportMapView
-):
-    pass
-
-
-class CataloniaResidualFrequencyMapView(
-    CataloniaAtlasMapView, GermanyResidualFrequencyMapView
-):
-    pass
-
-
-class CataloniaBiowasteFrequencyMapView(
-    CataloniaAtlasMapView, GermanyBiowasteFrequencyMapView
-):
-    pass
-
-
-class CataloniaCombinedFrequencyMapView(
-    CataloniaAtlasMapView, GermanyCombinedFrequencyMapView
-):
-    pass
-
-
-class CataloniaResidualCollectionCountMapView(
-    CataloniaAtlasMapView, GermanyResidualCollectionCountMapView
-):
-    pass
-
-
-class CataloniaBiowasteCollectionCountMapView(
-    CataloniaAtlasMapView, GermanyBiowasteCollectionCountMapView
-):
-    pass
-
-
-class CataloniaCombinedCollectionCountMapView(
-    CataloniaAtlasMapView, GermanyCombinedCollectionCountMapView
-):
-    pass
-
-
-class CataloniaCollectionCountRatioMapView(
-    CataloniaAtlasMapView, GermanyCollectionCountRatioMapView
-):
-    pass
-
-
-class CataloniaResidualFeeSystemMapView(
-    CataloniaAtlasMapView, GermanyResidualFeeSystemMapView
-):
-    pass
-
-
-class CataloniaBiowasteFeeSystemMapView(
-    CataloniaAtlasMapView, GermanyBiowasteFeeSystemMapView
-):
-    pass
-
-
-class CataloniaCombinedFeeSystemMapView(
-    CataloniaAtlasMapView, GermanyCombinedFeeSystemMapView
-):
-    pass
-
-
-class CataloniaResidualCollectionAmountMapView(
-    CataloniaAtlasMapView, GermanyResidualCollectionAmountMapView
-):
-    pass
-
-
-class CataloniaBiowasteCollectionAmountMapView(
-    CataloniaAtlasMapView, GermanyBiowasteCollectionAmountMapView
-):
-    pass
-
-
-class CataloniaGreenWasteCollectionAmountMapView(
-    CataloniaAtlasMapView, GermanyGreenWasteCollectionAmountMapView
-):
-    pass
-
-
-class CataloniaOrganicCollectionAmountMapView(
-    CataloniaAtlasMapView, GermanyOrganicCollectionAmountMapView
-):
-    pass
-
-
-class CataloniaOrganicWasteRatioMapView(
-    CataloniaAtlasMapView, GermanyOrganicWasteRatioMapView
-):
-    pass
-
-
-class CataloniaBiowasteMinBinSizeMapView(
-    CataloniaAtlasMapView, GermanyBiowasteMinBinSizeMapView
-):
-    pass
-
-
-class CataloniaResidualMinBinSizeMapView(
-    CataloniaAtlasMapView, GermanyResidualMinBinSizeMapView
-):
-    pass
-
-
-class CataloniaBiowasteRequiredBinCapacityMapView(
-    CataloniaAtlasMapView, GermanyBiowasteRequiredBinCapacityMapView
-):
-    pass
-
-
-class CataloniaResidualRequiredBinCapacityMapView(
-    CataloniaAtlasMapView, GermanyResidualRequiredBinCapacityMapView
-):
-    pass
+globals().update(
+    {
+        view_name: _build_country_variant_map_view(
+            view_name,
+            CataloniaAtlasMapView,
+            inherited_view,
+        )
+        for view_name, inherited_view in CATALONIA_GERMANY_VARIANT_VIEWS
+    }
+)
 
 
 class GermanyWasteRatioMapView(GermanyAtlasMapView):
@@ -1497,59 +1412,17 @@ class GermanyBWRPPopulationDensityMapView(GermanyBWRPAtlasMapView):
     map_route_key = "population_density"
 
 
-class CataloniaWasteRatioMapView(CataloniaAtlasMapView, GermanyWasteRatioMapView):
-    pass
+CataloniaWasteRatioMapView = _build_country_variant_map_view(
+    "CataloniaWasteRatioMapView",
+    CataloniaAtlasMapView,
+    GermanyWasteRatioMapView,
+)
 
-
-class CataloniaPopulationDensityMapView(
-    CataloniaAtlasMapView, GermanyPopulationDensityMapView
-):
-    pass
-
-
-for _catalonia_view, _germany_view in (
-    (CataloniaOrgaLevelMapView, GermanyOrgaLevelMapView),
-    (
-        CataloniaGreenWasteCollectionSystemCountMapView,
-        GermanyGreenWasteCollectionSystemCountMapView,
-    ),
-    (CataloniaCollectionPointCountMapView, GermanyCollectionPointCountMapView),
-    (CataloniaConnectionRateMapView, GermanyConnectionRateMapView),
-    (CataloniaFoodWasteCategoryMapView, GermanyFoodWasteCategoryMapView),
-    (CataloniaPaperBagsMapView, GermanyPaperBagsMapView),
-    (CataloniaPlasticBagsMapView, GermanyPlasticBagsMapView),
-    (CataloniaCollectionSupportMapView, GermanyCollectionSupportMapView),
-    (CataloniaResidualFrequencyMapView, GermanyResidualFrequencyMapView),
-    (CataloniaBiowasteFrequencyMapView, GermanyBiowasteFrequencyMapView),
-    (CataloniaCombinedFrequencyMapView, GermanyCombinedFrequencyMapView),
-    (CataloniaResidualCollectionCountMapView, GermanyResidualCollectionCountMapView),
-    (CataloniaBiowasteCollectionCountMapView, GermanyBiowasteCollectionCountMapView),
-    (CataloniaCombinedCollectionCountMapView, GermanyCombinedCollectionCountMapView),
-    (CataloniaCollectionCountRatioMapView, GermanyCollectionCountRatioMapView),
-    (CataloniaResidualFeeSystemMapView, GermanyResidualFeeSystemMapView),
-    (CataloniaBiowasteFeeSystemMapView, GermanyBiowasteFeeSystemMapView),
-    (CataloniaCombinedFeeSystemMapView, GermanyCombinedFeeSystemMapView),
-    (CataloniaResidualCollectionAmountMapView, GermanyResidualCollectionAmountMapView),
-    (CataloniaBiowasteCollectionAmountMapView, GermanyBiowasteCollectionAmountMapView),
-    (CataloniaGreenWasteCollectionAmountMapView, GermanyGreenWasteCollectionAmountMapView),
-    (CataloniaOrganicCollectionAmountMapView, GermanyOrganicCollectionAmountMapView),
-    (CataloniaOrganicWasteRatioMapView, GermanyOrganicWasteRatioMapView),
-    (CataloniaBiowasteMinBinSizeMapView, GermanyBiowasteMinBinSizeMapView),
-    (CataloniaResidualMinBinSizeMapView, GermanyResidualMinBinSizeMapView),
-    (
-        CataloniaBiowasteRequiredBinCapacityMapView,
-        GermanyBiowasteRequiredBinCapacityMapView,
-    ),
-    (
-        CataloniaResidualRequiredBinCapacityMapView,
-        GermanyResidualRequiredBinCapacityMapView,
-    ),
-    (CataloniaWasteRatioMapView, GermanyWasteRatioMapView),
-    (CataloniaPopulationDensityMapView, GermanyPopulationDensityMapView),
-):
-    _catalonia_view.template_name = _germany_view.template_name
-    _catalonia_view.map_title = _germany_view.map_title
-    _catalonia_view.map_route_key = _germany_view.map_route_key
+CataloniaPopulationDensityMapView = _build_country_variant_map_view(
+    "CataloniaPopulationDensityMapView",
+    CataloniaAtlasMapView,
+    GermanyPopulationDensityMapView,
+)
 
 
 class NetherlandsCollectionSystemMapView(CollectionSystemMapView):


### PR DESCRIPTION
Superseded by the current `main` integration; closing before branch cleanup.