### PR TITLE
Skip expensive metrics on collection research list

### DIFF
--- a/sources/waste_collection/apps.py
+++ b/sources/waste_collection/apps.py
@@ -7,6 +7,11 @@ class WasteCollectionConfig(AppConfig):
     verbose_name = "Sources / Waste Collection"
 
     def ready(self):
+        try:
+            from .patches import disable_research_metrics  # noqa: F401
+        except Exception:
+            pass
+
         signal_module = None
         try:
             from . import signals as signal_module

--- a/sources/waste_collection/patches/__init__.py
+++ b/sources/waste_collection/patches/__init__.py
@@ -1,0 +1,4 @@
+"""Runtime patches for waste collection app."""
+
+# Import patch modules in apps.py ``ready`` to avoid side effects during
+# module import when the app is not installed.

--- a/sources/waste_collection/patches/disable_research_metrics.py
+++ b/sources/waste_collection/patches/disable_research_metrics.py
@@ -1,0 +1,59 @@
+"""Disable expensive metric loading on the research list serializer."""
+
+from __future__ import annotations
+
+from types import MethodType
+from typing import Any, Callable
+
+from sources.waste_collection.serializers import CollectionResearchSerializer
+
+
+def _make_empty_method(instance: Any) -> Callable[[Any, Any], list[Any]]:
+    def _empty_method(_self: Any, user: Any = None) -> list[Any]:  # noqa: ANN401
+        return []
+
+    return MethodType(_empty_method, instance)
+
+
+def _temporarily_disable_metric_queries(instance: Any):
+    attr_names = (
+        "collectionpropertyvalues_for_display",
+        "aggregatedcollectionpropertyvalues_for_display",
+    )
+    originals = {}
+    for name in attr_names:
+        originals[name] = (
+            name in instance.__dict__,
+            instance.__dict__.get(name),
+        )
+        instance.__dict__[name] = _make_empty_method(instance)
+    return originals
+
+
+def _restore_metric_queries(instance: Any, originals: dict[str, tuple[bool, Any]]):
+    for name, (had_instance_attr, value) in originals.items():
+        if had_instance_attr:
+            instance.__dict__[name] = value
+        else:
+            instance.__dict__.pop(name, None)
+
+
+def _patch_collection_research_serializer() -> None:
+    if getattr(CollectionResearchSerializer, "_metrics_patch_applied", False):
+        return
+
+    original_to_representation = CollectionResearchSerializer.to_representation
+
+    def patched_to_representation(self, instance):  # type: ignore[override]
+        originals = _temporarily_disable_metric_queries(instance)
+        try:
+            return original_to_representation(self, instance)
+        finally:
+            _restore_metric_queries(instance, originals)
+
+    CollectionResearchSerializer.include_collection_metrics = False
+    CollectionResearchSerializer.to_representation = patched_to_representation  # type: ignore[assignment]
+    CollectionResearchSerializer._metrics_patch_applied = True  # type: ignore[attr-defined]
+
+
+_patch_collection_research_serializer()

--- a/sources/waste_collection/tests/test_collection_research_metrics.py
+++ b/sources/waste_collection/tests/test_collection_research_metrics.py
@@ -1,0 +1,36 @@
+from unittest.mock import patch
+
+from django.urls import reverse
+from rest_framework import status
+
+from sources.waste_collection.models import Collection
+from sources.waste_collection.tests.test_viewsets import CollectionViewSetTestCase
+
+
+class CollectionResearchPerformanceTests(CollectionViewSetTestCase):
+    def test_list_endpoint_skips_expensive_collection_metrics(self):
+        self.client.force_login(self.regular_user)
+
+        with patch.object(
+            Collection,
+            "collectionpropertyvalues_for_display",
+            side_effect=AssertionError("collection metrics should not be loaded"),
+        ), patch.object(
+            Collection,
+            "aggregatedcollectionpropertyvalues_for_display",
+            side_effect=AssertionError(
+                "aggregated collection metrics should not be loaded"
+            ),
+        ):
+            response = self.client.get(
+                reverse("api-waste-collection-list"),
+                {"scope": "private", "id": [self.private_collection.pk]},
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = self._response_results(response)
+        result = next(
+            item for item in results if item["id"] == self.private_collection.pk
+        )
+        self.assertNotIn("specific_waste_collected_2024", result)
+        self.assertNotIn("connection_rate_2024", result)


### PR DESCRIPTION
## Summary
- load a lightweight runtime patch that disables the per-collection metric queries on the research list serializer
- add a regression test to ensure the list endpoint no longer touches the expensive helpers

This mirrors the local hotfix that kept the list endpoint from timing out when MCP research workflows fetch the collection list.
