### PR TITLE
Fix region GeoJSON cache invalidation for attribute changes

### DIFF
--- a/maps/signals.py
+++ b/maps/signals.py
@@ -7,7 +7,15 @@ from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.utils import timezone
 
-from .models import Catchment, GeoPolygon, LauRegion, NutsRegion, Region
+from .models import (
+    Catchment,
+    GeoPolygon,
+    LauRegion,
+    NutsRegion,
+    Region,
+    RegionAttributeTextValue,
+    RegionAttributeValue,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +85,20 @@ def invalidate_region_cache(sender, instance, **kwargs):
     # Invalidate NUTS cache if the region has an associated NUTS region.
     if hasattr(instance, "nutsregion"):
         clear_geojson_cache_pattern("nuts_geojson:*")
+
+
+@receiver(post_save, sender=RegionAttributeValue)
+@receiver(post_delete, sender=RegionAttributeValue)
+@receiver(post_save, sender=RegionAttributeTextValue)
+@receiver(post_delete, sender=RegionAttributeTextValue)
+def invalidate_region_attribute_cache(sender, instance, **kwargs):
+    """
+    Invalidate cached Region GeoJSON when values rendered for a region change.
+    """
+    geojson_cache = get_geojson_cache()
+    if instance.region_id:
+        safe_cache_delete(geojson_cache, f"region_geojson:id:{instance.region_id}")
+    clear_geojson_cache_pattern("region_geojson:*")
 
 
 @receiver(post_save, sender=GeoPolygon)

--- a/maps/tests/test_signals.py
+++ b/maps/tests/test_signals.py
@@ -1,0 +1,61 @@
+from unittest.mock import Mock, call, patch
+
+from django.db.models.signals import post_delete, post_save
+from django.test import SimpleTestCase
+
+from maps.models import (
+    RegionAttributeTextValue,
+    RegionAttributeValue,
+)
+
+
+class RegionAttributeGeoJSONCacheInvalidationTests(SimpleTestCase):
+    def test_numeric_attribute_save_and_delete_invalidate_region_geojson_cache(self):
+        value = RegionAttributeValue(
+            region_id=123,
+            property_id=456,
+            owner_id=1,
+            value=12.5,
+        )
+        geojson_cache = Mock()
+
+        with (
+            patch("maps.signals.get_geojson_cache", return_value=geojson_cache),
+            patch("maps.signals.clear_geojson_cache_pattern") as clear_pattern,
+        ):
+            post_save.send(sender=RegionAttributeValue, instance=value)
+            post_delete.send(sender=RegionAttributeValue, instance=value)
+
+        self.assertEqual(
+            geojson_cache.delete.call_args_list,
+            [call("region_geojson:id:123"), call("region_geojson:id:123")],
+        )
+        self.assertEqual(
+            clear_pattern.call_args_list,
+            [call("region_geojson:*"), call("region_geojson:*")],
+        )
+
+    def test_text_attribute_save_and_delete_invalidate_region_geojson_cache(self):
+        value = RegionAttributeTextValue(
+            region_id=123,
+            categorical_attribute_id=789,
+            owner_id=1,
+            value="urban",
+        )
+        geojson_cache = Mock()
+
+        with (
+            patch("maps.signals.get_geojson_cache", return_value=geojson_cache),
+            patch("maps.signals.clear_geojson_cache_pattern") as clear_pattern,
+        ):
+            post_save.send(sender=RegionAttributeTextValue, instance=value)
+            post_delete.send(sender=RegionAttributeTextValue, instance=value)
+
+        self.assertEqual(
+            geojson_cache.delete.call_args_list,
+            [call("region_geojson:id:123"), call("region_geojson:id:123")],
+        )
+        self.assertEqual(
+            clear_pattern.call_args_list,
+            [call("region_geojson:*"), call("region_geojson:*")],
+        )


### PR DESCRIPTION
## Summary
- Add signal handlers for `RegionAttributeValue` and `RegionAttributeTextValue` save/delete events.
- Invalidate the affected region detail cache key and broad `region_geojson:*` keys when attribute values change.
- Add focused regression coverage for numeric and text region attributes.

Fixes #167.

## Tests
- `docker compose --project-directory /home/phillipp/projects/BRIT-worktrees/issue-167-region-attribute-cache -f /home/phillipp/projects/BRIT-worktrees/issue-167-region-attribute-cache/compose.yml -f /home/phillipp/projects/BRIT-worktrees/issue-167-region-attribute-cache/compose.worktree.yml -p brit-issue-167-region-attribute-cache run --rm --no-deps web python manage.py test maps.tests.test_signals --settings=brit.settings.testrunner --keepdb --noinput --parallel 1`
- `docker compose --project-directory /home/phillipp/projects/BRIT-worktrees/issue-167-region-attribute-cache -f /home/phillipp/projects/BRIT-worktrees/issue-167-region-attribute-cache/compose.yml -f /home/phillipp/projects/BRIT-worktrees/issue-167-region-attribute-cache/compose.worktree.yml -p brit-issue-167-region-attribute-cache run --rm --no-deps web python manage.py test maps.tests.test_views.GeoJSONCachingTests --settings=brit.settings.testrunner --keepdb --noinput --parallel 1`
- `docker compose --project-directory /home/phillipp/projects/BRIT-worktrees/issue-167-region-attribute-cache -f /home/phillipp/projects/BRIT-worktrees/issue-167-region-attribute-cache/compose.yml -f /home/phillipp/projects/BRIT-worktrees/issue-167-region-attribute-cache/compose.worktree.yml -p brit-issue-167-region-attribute-cache run --rm --no-deps web ruff check maps/signals.py maps/tests/test_signals.py`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->