### PR TITLE
Fix Redis cache SSL options for non-TLS URLs

### DIFF
--- a/brit/settings/settings.py
+++ b/brit/settings/settings.py
@@ -163,29 +163,35 @@ REGISTRATION_FORM = "users.forms.UserRegistrationForm"
 LOGIN_REDIRECT_URL = "home"
 LOGIN_URL = "/users/login/"
 
+
+def _build_redis_cache_options(redis_url, **extra_options):
+    options = {
+        "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        "COMPRESSOR": "django_redis.compressors.zlib.ZlibCompressor",
+        "IGNORE_EXCEPTIONS": True,
+        **extra_options,
+    }
+    if redis_url and redis_url.startswith("rediss://"):
+        options["CONNECTION_POOL_KWARGS"] = {"ssl_cert_reqs": ssl.CERT_NONE}
+    return options
+
+
 # Redis and Caching
+REDIS_URL = os.environ.get("REDIS_URL")
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": os.environ.get("REDIS_URL"),
-        "OPTIONS": {
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            "COMPRESSOR": "django_redis.compressors.zlib.ZlibCompressor",
-            "IGNORE_EXCEPTIONS": True,
-            "CONNECTION_POOL_KWARGS": {"ssl_cert_reqs": None},
-        },
+        "LOCATION": REDIS_URL,
+        "OPTIONS": _build_redis_cache_options(REDIS_URL),
     },
     "geojson": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": os.environ.get("REDIS_URL"),
+        "LOCATION": REDIS_URL,
         "TIMEOUT": 86400,  # 24 hours
-        "OPTIONS": {
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            "COMPRESSOR": "django_redis.compressors.zlib.ZlibCompressor",
-            "IGNORE_EXCEPTIONS": True,
-            "CONNECTION_POOL_KWARGS": {"ssl_cert_reqs": None},
-            "KEY_PREFIX": "geojson",  # Differentiate keys for the geojson cache
-        },
+        "OPTIONS": _build_redis_cache_options(
+            REDIS_URL,
+            KEY_PREFIX="geojson",  # Differentiate keys for the geojson cache
+        ),
     },
 }
 
@@ -281,8 +287,8 @@ CRISPY_TEMPLATE_PACK = "bootstrap5"
 
 COOKIE_CONSENT_NAME = "cookie_consent"
 
-CELERY_BROKER_URL = os.environ.get("REDIS_URL")
-CELERY_RESULT_BACKEND = os.environ.get("REDIS_URL")
+CELERY_BROKER_URL = REDIS_URL
+CELERY_RESULT_BACKEND = REDIS_URL
 CELERY_BROKER_USE_SSL = {"ssl_cert_reqs": ssl.CERT_NONE}
 CELERY_REDIS_BACKEND_USE_SSL = {"ssl_cert_reqs": ssl.CERT_NONE}
 

--- a/brit/tests/test_settings.py
+++ b/brit/tests/test_settings.py
@@ -1,0 +1,20 @@
+import ssl
+
+from django.test import SimpleTestCase
+
+from brit.settings.settings import _build_redis_cache_options
+
+
+class RedisCacheOptionsTests(SimpleTestCase):
+    def test_plain_redis_url_does_not_receive_ssl_connection_kwargs(self):
+        options = _build_redis_cache_options("redis://redis:6379/0")
+
+        self.assertNotIn("CONNECTION_POOL_KWARGS", options)
+
+    def test_rediss_url_receives_ssl_connection_kwargs(self):
+        options = _build_redis_cache_options("rediss://redis:6379/0")
+
+        self.assertEqual(
+            options["CONNECTION_POOL_KWARGS"],
+            {"ssl_cert_reqs": ssl.CERT_NONE},
+        )


### PR DESCRIPTION
## Summary
- Build Django Redis cache options conditionally so `ssl_cert_reqs` is only passed for `rediss://` URLs.
- Reuse the parsed `REDIS_URL` setting for caches and Celery URLs.
- Add focused settings tests for plain `redis://` and TLS `rediss://` cache options.

This avoids `redis-py` 7.x `AbstractConnection.__init__()` errors when a plain Redis URL is configured.

## Tests
- `docker compose --project-directory /home/phillipp/projects/BRIT -f /home/phillipp/projects/BRIT/compose.yml run --rm --no-deps web python manage.py test brit.tests.test_settings --settings=brit.settings.testrunner --keepdb --noinput --parallel 1`
- `docker compose --project-directory /home/phillipp/projects/BRIT -f /home/phillipp/projects/BRIT/compose.yml run --rm --no-deps web ruff check brit/settings/settings.py brit/tests/test_settings.py`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->