### PR TITLE
WS1-A: move waste collection review context behind hooks

### DIFF
--- a/sources/waste_collection/apps.py
+++ b/sources/waste_collection/apps.py
@@ -18,6 +18,12 @@ class WasteCollectionConfig(AppConfig):
             pass
 
         try:
+            review_hooks = import_module("sources.waste_collection.review_hooks")
+            review_hooks.register_review_hooks()
+        except Exception:
+            logger.exception("Failed to register waste_collection review hooks.")
+
+        try:
             signal_module = import_module("sources.waste_collection.signals")
         except Exception:
             logger.exception("Failed to import waste_collection signal handlers.")

--- a/sources/waste_collection/review_hooks.py
+++ b/sources/waste_collection/review_hooks.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import logging
+from importlib import import_module
+
+from django.urls import reverse
+
+from utils.object_management.review_context import (
+    _serialize_m2m_sources,
+    _serialize_value,
+)
+from utils.object_management.review_hooks import (
+    register_breadcrumb_module,
+    register_review_context_enricher,
+    register_review_search_fields,
+    register_review_update_context,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def register_review_hooks() -> None:
+    register_breadcrumb_module(
+        "waste_collection",
+        label="Waste Collection",
+        url_name="wastecollection-explorer",
+        parent_label="Sources",
+        parent_url_name="sources-explorer",
+    )
+    register_review_context_enricher(
+        "waste_collection.collection",
+        enrich_collection_review_context,
+    )
+    register_review_context_enricher(
+        "waste_collection.collectionpropertyvalue",
+        enrich_collection_property_value_review_context,
+    )
+    register_review_search_fields(
+        "waste_collection.collection",
+        ["catchment__name", "waste_category__name", "collection_system__name"],
+    )
+    register_review_update_context(
+        "waste_collection.collection",
+        serialize_collection_update_context,
+    )
+
+
+def is_collection(obj: object) -> bool:
+    return (
+        obj._meta.app_label == "waste_collection"
+        and obj._meta.model_name == "collection"
+    )
+
+
+def is_collection_property_value(obj: object) -> bool:
+    return (
+        obj._meta.app_label == "waste_collection"
+        and obj._meta.model_name == "collectionpropertyvalue"
+    )
+
+
+def enrich_collection_review_context(obj: object) -> dict[str, object]:
+    return {
+        "flyers": _serialize_collection_flyers(obj),
+        "frequency_display": _serialize_collection_frequency(obj),
+    }
+
+
+def enrich_collection_property_value_review_context(obj: object) -> dict[str, object]:
+    context: dict[str, object] = {
+        "parent_collection": _serialize_parent_collection(obj),
+    }
+    if not obj.is_derived:
+        context["value_timeline"] = _serialize_cpv_timeline(obj)
+    return context
+
+
+def serialize_collection_update_context(
+    user: object,
+    obj: object,
+) -> dict[str, object] | None:
+    if not is_collection(obj):
+        return None
+
+    is_owner = bool(
+        user and user.is_authenticated and obj.owner_id == user.id
+    )
+    if not is_owner:
+        return {
+            "available": False,
+            "detail": (
+                "Only the collection owner may use the programmatic update endpoint."
+            ),
+        }
+
+    waste_category = obj.effective_waste_category
+    valid_from = obj.valid_from
+    return {
+        "available": True,
+        "update_url": reverse("api-waste-collection-update", kwargs={"pk": obj.pk}),
+        "expected_identity": {
+            "expected_catchment": str(obj.catchment),
+            "expected_catchment_id": obj.catchment.pk if obj.catchment else None,
+            "expected_waste_category": str(waste_category) if waste_category else "",
+            "expected_waste_category_id": waste_category.pk if waste_category else None,
+            "expected_collection_system": str(obj.collection_system),
+            "expected_collection_system_id": (
+                obj.collection_system.pk if obj.collection_system else None
+            ),
+            "expected_publication_status": obj.publication_status,
+            "expected_valid_from": valid_from.isoformat() if valid_from else None,
+        },
+        "mutable_fields": [
+            "collector",
+            "frequency",
+            "fee_system",
+            "bin_configuration",
+            "allowed_materials",
+            "forbidden_materials",
+            "sources",
+            "flyer_urls",
+            "established",
+            "connection_type",
+            "min_bin_size",
+            "required_bin_capacity",
+            "required_bin_capacity_reference",
+            "comments",
+            "description",
+        ],
+    }
+
+
+def _serialize_cpv_timeline(obj: object) -> list[dict[str, object]]:
+    try:
+        collection = obj.collection
+        siblings = (
+            obj.__class__.objects.filter(
+                collection_id__in=collection.version_chain_ids,
+                property_id=obj.property_id,
+                is_derived=False,
+            )
+            .exclude(pk=obj.pk)
+            .select_related("unit")
+            .order_by("year", "pk")
+        )
+        return [
+            {
+                "id": sibling.pk,
+                "year": sibling.year,
+                "average": sibling.average,
+                "standard_deviation": sibling.standard_deviation,
+                "unit": str(sibling.unit) if sibling.unit else None,
+                "publication_status": sibling.publication_status,
+            }
+            for sibling in siblings
+        ]
+    except Exception:
+        logger.debug("Could not build CPV timeline for %s", obj.pk, exc_info=True)
+        return []
+
+
+def _serialize_parent_collection(obj: object) -> dict[str, object]:
+    try:
+        collection = obj.collection
+        return {
+            "id": collection.pk,
+            "name": str(collection),
+            "sources": _serialize_m2m_sources(collection),
+            "flyers": _serialize_collection_flyers(collection),
+        }
+    except Exception:
+        logger.debug(
+            "Could not serialize parent collection for CPV %s",
+            obj.pk,
+            exc_info=True,
+        )
+        return {}
+
+
+def _serialize_collection_flyers(obj: object) -> list[dict[str, object]]:
+    return [
+        {
+            "id": flyer.pk,
+            "url": flyer.url,
+            "url_valid": flyer.url_valid,
+            "url_checked": _serialize_value(flyer.url_checked),
+            "url_valid_is_advisory": True,
+            "title": flyer.title,
+        }
+        for flyer in obj.flyers.order_by("pk")
+    ]
+
+
+def _serialize_collection_frequency(obj: object) -> dict[str, object] | None:
+    frequency = obj.frequency
+    if frequency is None:
+        return None
+    try:
+        schedule_service = _get_collection_frequency_schedule_service()
+        if schedule_service is None:
+            raise LookupError("Collection frequency schedule service is unavailable")
+        rows = schedule_service.rows_from_frequency(frequency)
+        display_rows = schedule_service.display_rows(frequency)
+        is_year_round = (
+            len(display_rows) == 1 and display_rows[0]["segment"] == "All year"
+        )
+        return {
+            "id": frequency.pk,
+            "canonical_label": frequency.name,
+            "type": frequency.type,
+            "schedule_summary": schedule_service.summary(rows),
+            "rows": display_rows,
+            "is_year_round": is_year_round,
+            "summary": display_rows[0]["standard"] if is_year_round else None,
+            "options": display_rows[0]["options"] if is_year_round else None,
+        }
+    except Exception:
+        logger.debug(
+            "Could not serialize collection frequency for %s",
+            obj.pk,
+            exc_info=True,
+        )
+        return {
+            "id": frequency.pk,
+            "canonical_label": frequency.name,
+            "type": frequency.type,
+            "schedule_summary": None,
+            "rows": [],
+            "is_year_round": False,
+            "summary": None,
+            "options": [],
+        }
+
+
+def _get_collection_frequency_schedule_service():
+    try:
+        module = import_module("sources.waste_collection.frequency_service")
+    except (ImportError, ModuleNotFoundError):
+        return None
+    try:
+        return module.CollectionFrequencyScheduleService
+    except AttributeError:
+        return None

--- a/sources/waste_collection/review_hooks.py
+++ b/sources/waste_collection/review_hooks.py
@@ -42,6 +42,7 @@ def register_review_hooks() -> None:
     register_review_update_context(
         "waste_collection.collection",
         serialize_collection_update_context,
+        context_key="collection_update",
     )
 
 

--- a/sources/waste_collection/tests/test_apps.py
+++ b/sources/waste_collection/tests/test_apps.py
@@ -1,6 +1,6 @@
 from importlib import import_module
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from django.test import SimpleTestCase
 
@@ -13,10 +13,19 @@ class WasteCollectionConfigReadyTests(SimpleTestCase):
         self.app_config = WasteCollectionConfig("sources.waste_collection", app_module)
 
     def test_ready_logs_and_returns_when_signal_import_fails(self):
+        review_hooks = SimpleNamespace(register_review_hooks=Mock())
+
+        def import_side_effect(module_name):
+            if module_name == "sources.waste_collection.signals":
+                raise RuntimeError("boom")
+            if module_name == "sources.waste_collection.review_hooks":
+                return review_hooks
+            return SimpleNamespace()
+
         with (
             patch(
                 "sources.waste_collection.apps.import_module",
-                side_effect=RuntimeError("boom"),
+                side_effect=import_side_effect,
             ),
             patch("sources.waste_collection.apps.logger") as logger,
         ):
@@ -25,18 +34,27 @@ class WasteCollectionConfigReadyTests(SimpleTestCase):
         logger.exception.assert_called_once_with(
             "Failed to import waste_collection signal handlers."
         )
+        review_hooks.register_review_hooks.assert_called_once_with()
 
     def test_ready_connects_collection_property_value_signal_handlers(self):
         signal_module = SimpleNamespace(
             sync_derived_cpv_on_save=object(),
             sync_derived_cpv_on_delete=object(),
         )
+        review_hooks = SimpleNamespace(register_review_hooks=Mock())
         collection_property_value_model = object()
+
+        def import_side_effect(module_name):
+            if module_name == "sources.waste_collection.signals":
+                return signal_module
+            if module_name == "sources.waste_collection.review_hooks":
+                return review_hooks
+            return SimpleNamespace()
 
         with (
             patch(
                 "sources.waste_collection.apps.import_module",
-                return_value=signal_module,
+                side_effect=import_side_effect,
             ),
             patch.object(
                 self.app_config,
@@ -48,6 +66,7 @@ class WasteCollectionConfigReadyTests(SimpleTestCase):
         ):
             self.app_config.ready()
 
+        review_hooks.register_review_hooks.assert_called_once_with()
         post_save_connect.assert_called_once_with(
             signal_module.sync_derived_cpv_on_save,
             sender=collection_property_value_model,
@@ -64,11 +83,19 @@ class WasteCollectionConfigReadyTests(SimpleTestCase):
             sync_derived_cpv_on_save=object(),
             sync_derived_cpv_on_delete=object(),
         )
+        review_hooks = SimpleNamespace(register_review_hooks=Mock())
+
+        def import_side_effect(module_name):
+            if module_name == "sources.waste_collection.signals":
+                return signal_module
+            if module_name == "sources.waste_collection.review_hooks":
+                return review_hooks
+            return SimpleNamespace()
 
         with (
             patch(
                 "sources.waste_collection.apps.import_module",
-                return_value=signal_module,
+                side_effect=import_side_effect,
             ),
             patch.object(
                 self.app_config,
@@ -79,18 +106,29 @@ class WasteCollectionConfigReadyTests(SimpleTestCase):
         ):
             self.app_config.ready()
 
+        review_hooks.register_review_hooks.assert_called_once_with()
         logger.warning.assert_called_once_with(
             "Waste collection signal registration skipped because CollectionPropertyValue could not be resolved."
         )
 
     def test_ready_imports_research_metrics_patch(self):
+        review_hooks = SimpleNamespace(register_review_hooks=Mock())
+        signal_module = SimpleNamespace(
+            sync_derived_cpv_on_save=object(),
+            sync_derived_cpv_on_delete=object(),
+        )
+
+        def import_side_effect(module_name):
+            if module_name == "sources.waste_collection.signals":
+                return signal_module
+            if module_name == "sources.waste_collection.review_hooks":
+                return review_hooks
+            return SimpleNamespace()
+
         with (
             patch(
                 "sources.waste_collection.apps.import_module",
-                return_value=SimpleNamespace(
-                    sync_derived_cpv_on_save=object(),
-                    sync_derived_cpv_on_delete=object(),
-                ),
+                side_effect=import_side_effect,
             ) as import_module_mock,
             patch.object(self.app_config, "get_model", return_value=object()),
             patch("django.db.models.signals.post_save.connect"),
@@ -103,3 +141,4 @@ class WasteCollectionConfigReadyTests(SimpleTestCase):
             "sources.waste_collection.patches.disable_research_metrics",
             imported_modules,
         )
+        self.assertIn("sources.waste_collection.review_hooks", imported_modules)

--- a/utils/object_management/api_views.py
+++ b/utils/object_management/api_views.py
@@ -157,9 +157,7 @@ class ReviewContextAPIView(APIView):
             include_history=include_history,
             history_limit=max(1, min(history_limit, 50)),
         )
-        update_context = get_review_update_context(request.user, obj)
-        if update_context is not None:
-            context["collection_update"] = update_context
+        context.update(get_review_update_context(request.user, obj))
 
         return Response(
             {

--- a/utils/object_management/api_views.py
+++ b/utils/object_management/api_views.py
@@ -13,6 +13,7 @@ from rest_framework.views import APIView
 from .models import ReviewAction
 from .permissions import UserCreatedObjectPermission
 from .review_context import build_review_context
+from .review_hooks import get_review_update_context
 from .views import ReviewDashboardView
 
 
@@ -156,9 +157,9 @@ class ReviewContextAPIView(APIView):
             include_history=include_history,
             history_limit=max(1, min(history_limit, 50)),
         )
-        collection_update = _serialize_collection_update_context(request.user, obj)
-        if collection_update is not None:
-            context["collection_update"] = collection_update
+        update_context = get_review_update_context(request.user, obj)
+        if update_context is not None:
+            context["collection_update"] = update_context
 
         return Response(
             {
@@ -177,60 +178,6 @@ def _get_review_object(*, content_type_id: int, object_id: int):
     if model_class is None:
         raise Http404("No model is registered for this content type.")
     return get_object_or_404(model_class, pk=object_id)
-
-
-def _serialize_collection_update_context(user, obj):
-    """Return owner-gated update hints for collection review items."""
-    if not (
-        obj._meta.app_label == "waste_collection"
-        and obj._meta.model_name == "collection"
-    ):
-        return None
-
-    is_owner = bool(
-        user
-        and getattr(user, "is_authenticated", False)
-        and getattr(obj, "owner_id", None) == getattr(user, "id", None)
-    )
-    if not is_owner:
-        return {
-            "available": False,
-            "detail": "Only the collection owner may use the programmatic update endpoint.",
-        }
-
-    waste_category = getattr(obj, "effective_waste_category", None)
-    valid_from = getattr(obj, "valid_from", None)
-    return {
-        "available": True,
-        "update_url": reverse("api-waste-collection-update", kwargs={"pk": obj.pk}),
-        "expected_identity": {
-            "expected_catchment": str(obj.catchment),
-            "expected_catchment_id": getattr(obj.catchment, "pk", None),
-            "expected_waste_category": str(waste_category) if waste_category else "",
-            "expected_waste_category_id": getattr(waste_category, "pk", None),
-            "expected_collection_system": str(obj.collection_system),
-            "expected_collection_system_id": getattr(obj.collection_system, "pk", None),
-            "expected_publication_status": getattr(obj, "publication_status", None),
-            "expected_valid_from": valid_from.isoformat() if valid_from else None,
-        },
-        "mutable_fields": [
-            "collector",
-            "frequency",
-            "fee_system",
-            "bin_configuration",
-            "allowed_materials",
-            "forbidden_materials",
-            "sources",
-            "flyer_urls",
-            "established",
-            "connection_type",
-            "min_bin_size",
-            "required_bin_capacity",
-            "required_bin_capacity_reference",
-            "comments",
-            "description",
-        ],
-    }
 
 
 def _to_bool(value):

--- a/utils/object_management/review_context.py
+++ b/utils/object_management/review_context.py
@@ -12,13 +12,13 @@ from __future__ import annotations
 import logging
 from datetime import date, datetime
 from decimal import Decimal
-from importlib import import_module
 from typing import Any
 
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 
 from .models import ReviewAction
+from .review_hooks import get_review_context_enrichments
 
 logger = logging.getLogger(__name__)
 
@@ -57,16 +57,7 @@ def build_review_context(
         ),
     }
 
-    # CPV-specific enrichments
-    if _is_collection_property_value(obj):
-        context["parent_collection"] = _serialize_parent_collection(obj)
-        if not getattr(obj, "is_derived", False):
-            context["value_timeline"] = _serialize_cpv_timeline(obj)
-
-    # Collection-specific enrichments
-    if _is_collection(obj):
-        context["flyers"] = _serialize_collection_flyers(obj)
-        context["frequency_display"] = _serialize_collection_frequency(obj)
+    context.update(get_review_context_enrichments(obj))
 
     if include_history:
         history = (
@@ -174,22 +165,6 @@ def validate_draft_payload(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _is_collection_property_value(obj: Any) -> bool:
-    """Check whether *obj* is a CollectionPropertyValue instance."""
-    return (
-        obj._meta.app_label == "waste_collection"
-        and obj._meta.model_name == "collectionpropertyvalue"
-    )
-
-
-def _is_collection(obj: Any) -> bool:
-    """Check whether *obj* is a Collection instance."""
-    return (
-        obj._meta.app_label == "waste_collection"
-        and obj._meta.model_name == "collection"
-    )
-
-
 def _serialize_m2m_sources(obj: Any) -> list[dict[str, Any]]:
     """Serialize the ``sources`` M2M relation into JSON-safe dicts."""
     if not hasattr(obj, "sources"):
@@ -225,127 +200,6 @@ def _serialize_related_display(obj: Any) -> dict[str, str | None]:
         else:
             display[field.name] = None
     return display
-
-
-def _serialize_cpv_timeline(obj: Any) -> list[dict[str, Any]]:
-    """Return historical values for the same property on the same collection chain.
-
-    Helps assess plausibility by comparing a value against its trend
-    across years. Only called for non-derived CollectionPropertyValues.
-    """
-    try:
-        collection = obj.collection
-        chain_ids = collection.version_chain_ids
-        model_class = obj.__class__
-        siblings = (
-            model_class.objects.filter(
-                collection_id__in=chain_ids,
-                property_id=obj.property_id,
-                is_derived=False,
-            )
-            .exclude(pk=obj.pk)
-            .select_related("unit")
-            .order_by("year", "pk")
-        )
-        return [
-            {
-                "id": sibling.pk,
-                "year": sibling.year,
-                "average": sibling.average,
-                "standard_deviation": sibling.standard_deviation,
-                "unit": str(sibling.unit) if sibling.unit else None,
-                "publication_status": getattr(sibling, "publication_status", None),
-            }
-            for sibling in siblings
-        ]
-    except Exception:
-        logger.debug("Could not build CPV timeline for %s", obj.pk, exc_info=True)
-        return []
-
-
-def _serialize_parent_collection(obj: Any) -> dict[str, Any]:
-    """Serialize the parent collection of a CPV with its sources and flyers."""
-    try:
-        collection = obj.collection
-        return {
-            "id": collection.pk,
-            "name": str(collection),
-            "sources": _serialize_m2m_sources(collection),
-            "flyers": _serialize_collection_flyers(collection),
-        }
-    except Exception:
-        logger.debug(
-            "Could not serialize parent collection for CPV %s",
-            obj.pk,
-            exc_info=True,
-        )
-        return {}
-
-
-def _serialize_collection_flyers(obj: Any) -> list[dict[str, Any]]:
-    """Serialize the ``flyers`` M2M on a Collection."""
-    if not hasattr(obj, "flyers"):
-        return []
-    return [
-        {
-            "id": flyer.pk,
-            "url": getattr(flyer, "url", None),
-            "url_valid": getattr(flyer, "url_valid", None),
-            "url_checked": _serialize_value(getattr(flyer, "url_checked", None)),
-            "url_valid_is_advisory": True,
-            "title": getattr(flyer, "title", ""),
-        }
-        for flyer in obj.flyers.order_by("pk")
-    ]
-
-
-def _serialize_collection_frequency(obj: Any) -> dict[str, Any] | None:
-    frequency = getattr(obj, "frequency", None)
-    if frequency is None:
-        return None
-    try:
-        schedule_service = _get_collection_frequency_schedule_service()
-        if schedule_service is None:
-            raise LookupError("Collection frequency schedule service is unavailable")
-        rows = schedule_service.rows_from_frequency(frequency)
-        display_rows = schedule_service.display_rows(frequency)
-        is_year_round = (
-            len(display_rows) == 1 and display_rows[0]["segment"] == "All year"
-        )
-        return {
-            "id": frequency.pk,
-            "canonical_label": frequency.name,
-            "type": getattr(frequency, "type", None),
-            "schedule_summary": schedule_service.summary(rows),
-            "rows": display_rows,
-            "is_year_round": is_year_round,
-            "summary": display_rows[0]["standard"] if is_year_round else None,
-            "options": display_rows[0]["options"] if is_year_round else None,
-        }
-    except Exception:
-        logger.debug(
-            "Could not serialize collection frequency for %s",
-            obj.pk,
-            exc_info=True,
-        )
-        return {
-            "id": frequency.pk,
-            "canonical_label": frequency.name,
-            "type": getattr(frequency, "type", None),
-            "schedule_summary": None,
-            "rows": [],
-            "is_year_round": False,
-            "summary": None,
-            "options": [],
-        }
-
-
-def _get_collection_frequency_schedule_service():
-    try:
-        module = import_module("sources.waste_collection.frequency_service")
-    except (ImportError, ModuleNotFoundError):
-        return None
-    return getattr(module, "CollectionFrequencyScheduleService", None)
 
 
 def _serialize_model_fields(obj: Any) -> dict[str, Any]:

--- a/utils/object_management/review_hooks.py
+++ b/utils/object_management/review_hooks.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+
+ReviewContextEnricher = Callable[[object], Mapping[str, object]]
+ReviewUpdateContextBuilder = Callable[[object, object], Mapping[str, object] | None]
+
+
+@dataclass(frozen=True)
+class BreadcrumbModule:
+    label: str
+    url_name: str | None
+    parent_label: str | None = None
+    parent_url_name: str | None = None
+
+
+_review_context_enrichers: dict[str, list[ReviewContextEnricher]] = {}
+_review_search_fields: dict[str, tuple[str, ...]] = {}
+_review_update_context_builders: dict[str, ReviewUpdateContextBuilder] = {}
+_breadcrumb_modules: dict[str, BreadcrumbModule] = {}
+
+
+def register_review_context_enricher(
+    model_label: str,
+    fn: ReviewContextEnricher,
+) -> None:
+    label = _normalize_model_label(model_label)
+    enrichers = _review_context_enrichers.setdefault(label, [])
+    if fn not in enrichers:
+        enrichers.append(fn)
+
+
+def get_review_context_enrichments(obj: object) -> dict[str, object]:
+    context: dict[str, object] = {}
+    for enricher in _review_context_enrichers.get(_model_label_for(obj), []):
+        context.update(enricher(obj))
+    return context
+
+
+def register_review_search_fields(
+    model_label: str,
+    fields: Iterable[str],
+) -> None:
+    _review_search_fields[_normalize_model_label(model_label)] = tuple(fields)
+
+
+def get_review_search_fields(model_class: object) -> tuple[str, ...]:
+    return _review_search_fields.get(_model_label_for(model_class), ())
+
+
+def register_review_update_context(
+    model_label: str,
+    fn: ReviewUpdateContextBuilder,
+) -> None:
+    _review_update_context_builders[_normalize_model_label(model_label)] = fn
+
+
+def get_review_update_context(user: object, obj: object) -> Mapping[str, object] | None:
+    builder = _review_update_context_builders.get(_model_label_for(obj))
+    if builder is None:
+        return None
+    return builder(user, obj)
+
+
+def register_breadcrumb_module(
+    app_label: str,
+    *,
+    label: str,
+    url_name: str | None,
+    parent_label: str | None = None,
+    parent_url_name: str | None = None,
+) -> None:
+    _breadcrumb_modules[app_label] = BreadcrumbModule(
+        label=label,
+        url_name=url_name,
+        parent_label=parent_label,
+        parent_url_name=parent_url_name,
+    )
+
+
+def get_breadcrumb_module(app_label: str) -> BreadcrumbModule | None:
+    return _breadcrumb_modules.get(app_label)
+
+
+def snapshot_review_hooks_for_tests() -> tuple[
+    dict[str, list[ReviewContextEnricher]],
+    dict[str, tuple[str, ...]],
+    dict[str, ReviewUpdateContextBuilder],
+    dict[str, BreadcrumbModule],
+]:
+    return (
+        {key: list(value) for key, value in _review_context_enrichers.items()},
+        dict(_review_search_fields),
+        dict(_review_update_context_builders),
+        dict(_breadcrumb_modules),
+    )
+
+
+def restore_review_hooks_for_tests(
+    snapshot: tuple[
+        dict[str, list[ReviewContextEnricher]],
+        dict[str, tuple[str, ...]],
+        dict[str, ReviewUpdateContextBuilder],
+        dict[str, BreadcrumbModule],
+    ],
+) -> None:
+    (
+        context_enrichers,
+        search_fields,
+        update_context_builders,
+        breadcrumb_modules,
+    ) = snapshot
+    _review_context_enrichers.clear()
+    _review_context_enrichers.update(context_enrichers)
+    _review_search_fields.clear()
+    _review_search_fields.update(search_fields)
+    _review_update_context_builders.clear()
+    _review_update_context_builders.update(update_context_builders)
+    _breadcrumb_modules.clear()
+    _breadcrumb_modules.update(breadcrumb_modules)
+
+
+def _model_label_for(model_or_obj: object) -> str:
+    return _normalize_model_label(
+        f"{model_or_obj._meta.app_label}.{model_or_obj._meta.model_name}"
+    )
+
+
+def _normalize_model_label(model_label: str) -> str:
+    return model_label.lower()

--- a/utils/object_management/review_hooks.py
+++ b/utils/object_management/review_hooks.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 
 ReviewContextEnricher = Callable[[object], Mapping[str, object]]
 ReviewUpdateContextBuilder = Callable[[object, object], Mapping[str, object] | None]
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -34,7 +37,13 @@ def register_review_context_enricher(
 def get_review_context_enrichments(obj: object) -> dict[str, object]:
     context: dict[str, object] = {}
     for enricher in _review_context_enrichers.get(_model_label_for(obj), []):
-        context.update(enricher(obj))
+        try:
+            context.update(enricher(obj))
+        except Exception:
+            logger.exception(
+                "Failed to build review context enrichment for %s.",
+                _model_label_for(obj),
+            )
     return context
 
 

--- a/utils/object_management/review_hooks.py
+++ b/utils/object_management/review_hooks.py
@@ -18,9 +18,15 @@ class BreadcrumbModule:
     parent_url_name: str | None = None
 
 
+@dataclass(frozen=True)
+class ReviewUpdateContextHook:
+    context_key: str
+    builder: ReviewUpdateContextBuilder
+
+
 _review_context_enrichers: dict[str, list[ReviewContextEnricher]] = {}
 _review_search_fields: dict[str, tuple[str, ...]] = {}
-_review_update_context_builders: dict[str, ReviewUpdateContextBuilder] = {}
+_review_update_context_builders: dict[str, ReviewUpdateContextHook] = {}
 _breadcrumb_modules: dict[str, BreadcrumbModule] = {}
 
 
@@ -61,15 +67,22 @@ def get_review_search_fields(model_class: object) -> tuple[str, ...]:
 def register_review_update_context(
     model_label: str,
     fn: ReviewUpdateContextBuilder,
+    *,
+    context_key: str = "update_context",
 ) -> None:
-    _review_update_context_builders[_normalize_model_label(model_label)] = fn
+    _review_update_context_builders[_normalize_model_label(model_label)] = (
+        ReviewUpdateContextHook(context_key=context_key, builder=fn)
+    )
 
 
-def get_review_update_context(user: object, obj: object) -> Mapping[str, object] | None:
-    builder = _review_update_context_builders.get(_model_label_for(obj))
-    if builder is None:
-        return None
-    return builder(user, obj)
+def get_review_update_context(user: object, obj: object) -> dict[str, object]:
+    hook = _review_update_context_builders.get(_model_label_for(obj))
+    if hook is None:
+        return {}
+    update_context = hook.builder(user, obj)
+    if update_context is None:
+        return {}
+    return {hook.context_key: update_context}
 
 
 def register_breadcrumb_module(
@@ -95,7 +108,7 @@ def get_breadcrumb_module(app_label: str) -> BreadcrumbModule | None:
 def snapshot_review_hooks_for_tests() -> tuple[
     dict[str, list[ReviewContextEnricher]],
     dict[str, tuple[str, ...]],
-    dict[str, ReviewUpdateContextBuilder],
+    dict[str, ReviewUpdateContextHook],
     dict[str, BreadcrumbModule],
 ]:
     return (
@@ -110,7 +123,7 @@ def restore_review_hooks_for_tests(
     snapshot: tuple[
         dict[str, list[ReviewContextEnricher]],
         dict[str, tuple[str, ...]],
-        dict[str, ReviewUpdateContextBuilder],
+        dict[str, ReviewUpdateContextHook],
         dict[str, BreadcrumbModule],
     ],
 ) -> None:

--- a/utils/object_management/tests/test_api_views.py
+++ b/utils/object_management/tests/test_api_views.py
@@ -21,13 +21,13 @@ from sources.waste_collection.models import (
     CollectionSeason,
     WasteFlyer,
 )
-from utils.object_management.api_views import _serialize_collection_update_context
-from utils.object_management.models import ReviewAction, UserCreatedObject
-from utils.object_management.review_context import (
-    _is_collection,
-    _is_collection_property_value,
-    build_review_context,
+from sources.waste_collection.review_hooks import (
+    is_collection,
+    is_collection_property_value,
+    serialize_collection_update_context,
 )
+from utils.object_management.models import ReviewAction, UserCreatedObject
+from utils.object_management.review_context import build_review_context
 from utils.properties.models import Property, Unit
 
 
@@ -286,7 +286,7 @@ class ReviewAPIViewsTests(TestCase):
         )
 
         self.assertIsNone(
-            _serialize_collection_update_context(self.owner, soilcom_collection)
+            serialize_collection_update_context(self.owner, soilcom_collection)
         )
 
     def test_review_context_collection_helpers_require_waste_collection_label(self):
@@ -309,10 +309,10 @@ class ReviewAPIViewsTests(TestCase):
             )
         )
 
-        self.assertFalse(_is_collection(soilcom_collection))
-        self.assertFalse(_is_collection_property_value(soilcom_cpv))
-        self.assertTrue(_is_collection(waste_collection))
-        self.assertTrue(_is_collection_property_value(waste_collection_cpv))
+        self.assertFalse(is_collection(soilcom_collection))
+        self.assertFalse(is_collection_property_value(soilcom_cpv))
+        self.assertTrue(is_collection(waste_collection))
+        self.assertTrue(is_collection_property_value(waste_collection_cpv))
 
     def test_review_context_rejects_invalid_history_limit(self):
         """history_limit must be parseable as integer."""
@@ -478,7 +478,7 @@ class ReviewAPIViewsTests(TestCase):
         )
 
     @patch(
-        "utils.object_management.review_context.import_module",
+        "sources.waste_collection.review_hooks.import_module",
         side_effect=ModuleNotFoundError("sources.waste_collection.frequency_service"),
     )
     def test_review_context_frequency_display_degrades_safely_without_plugin_service(

--- a/utils/object_management/tests/test_api_views.py
+++ b/utils/object_management/tests/test_api_views.py
@@ -280,6 +280,27 @@ class ReviewAPIViewsTests(TestCase):
         moderator_context = moderator_response.json()["context"]["collection_update"]
         self.assertFalse(moderator_context["available"])
 
+    def test_review_context_uses_registered_update_context_key(self):
+        url = reverse(
+            "object_management:api_review_context",
+            kwargs={
+                "content_type_id": self.content_type_id,
+                "object_id": self.review_collection.id,
+            },
+        )
+
+        self.client.force_login(self.owner)
+        with patch(
+            "utils.object_management.api_views.get_review_update_context",
+            return_value={"generic_update": {"available": True}},
+        ):
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        context = response.json()["context"]
+        self.assertEqual(context["generic_update"], {"available": True})
+        self.assertNotIn("collection_update", context)
+
     def test_collection_update_context_ignores_legacy_soilcom_label(self):
         soilcom_collection = SimpleNamespace(
             _meta=SimpleNamespace(app_label="soilcom", model_name="collection")

--- a/utils/object_management/tests/test_review_hooks.py
+++ b/utils/object_management/tests/test_review_hooks.py
@@ -73,9 +73,10 @@ class ReviewHookRegistryTests(SimpleTestCase):
                 "user_id": review_user.id,
                 "model": review_obj._meta.model_name,
             },
+            context_key="thing_update",
         )
 
         self.assertEqual(
             get_review_update_context(user, obj),
-            {"user_id": 1, "model": "thing"},
+            {"thing_update": {"user_id": 1, "model": "thing"}},
         )

--- a/utils/object_management/tests/test_review_hooks.py
+++ b/utils/object_management/tests/test_review_hooks.py
@@ -34,6 +34,23 @@ class ReviewHookRegistryTests(SimpleTestCase):
             {"plugin_label": "thing"},
         )
 
+    def test_context_enricher_errors_do_not_block_other_enrichers(self):
+        obj = SimpleNamespace(_meta=SimpleNamespace(app_label="demo", model_name="thing"))
+
+        def failing_enricher(review_obj):
+            raise RuntimeError("boom")
+
+        register_review_context_enricher("demo.thing", failing_enricher)
+        register_review_context_enricher(
+            "demo.thing",
+            lambda review_obj: {"plugin_label": review_obj._meta.model_name},
+        )
+
+        with self.assertLogs("utils.object_management.review_hooks", level="ERROR"):
+            context = get_review_context_enrichments(obj)
+
+        self.assertEqual(context, {"plugin_label": "thing"})
+
     def test_search_fields_are_resolved_by_model_label(self):
         model = SimpleNamespace(
             _meta=SimpleNamespace(app_label="demo", model_name="thing")

--- a/utils/object_management/tests/test_review_hooks.py
+++ b/utils/object_management/tests/test_review_hooks.py
@@ -1,0 +1,64 @@
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase
+
+from utils.object_management.review_hooks import (
+    get_review_context_enrichments,
+    get_review_search_fields,
+    get_review_update_context,
+    register_review_context_enricher,
+    register_review_search_fields,
+    register_review_update_context,
+    restore_review_hooks_for_tests,
+    snapshot_review_hooks_for_tests,
+)
+
+
+class ReviewHookRegistryTests(SimpleTestCase):
+    def setUp(self):
+        self.registry_snapshot = snapshot_review_hooks_for_tests()
+
+    def tearDown(self):
+        restore_review_hooks_for_tests(self.registry_snapshot)
+
+    def test_context_enrichers_are_resolved_by_model_label(self):
+        obj = SimpleNamespace(_meta=SimpleNamespace(app_label="demo", model_name="thing"))
+
+        register_review_context_enricher(
+            "demo.thing",
+            lambda review_obj: {"plugin_label": review_obj._meta.model_name},
+        )
+
+        self.assertEqual(
+            get_review_context_enrichments(obj),
+            {"plugin_label": "thing"},
+        )
+
+    def test_search_fields_are_resolved_by_model_label(self):
+        model = SimpleNamespace(
+            _meta=SimpleNamespace(app_label="demo", model_name="thing")
+        )
+
+        register_review_search_fields("demo.thing", ["related__name"])
+
+        self.assertEqual(
+            get_review_search_fields(model),
+            ("related__name",),
+        )
+
+    def test_update_context_hook_is_resolved_by_model_label(self):
+        user = SimpleNamespace(id=1)
+        obj = SimpleNamespace(_meta=SimpleNamespace(app_label="demo", model_name="thing"))
+
+        register_review_update_context(
+            "demo.thing",
+            lambda review_user, review_obj: {
+                "user_id": review_user.id,
+                "model": review_obj._meta.model_name,
+            },
+        )
+
+        self.assertEqual(
+            get_review_update_context(user, obj),
+            {"user_id": 1, "model": "thing"},
+        )

--- a/utils/object_management/views.py
+++ b/utils/object_management/views.py
@@ -47,6 +47,10 @@ from utils.object_management.permissions import (
     user_is_moderator_for_model,
 )
 from utils.object_management.review_filtering import ReviewItemFilter
+from utils.object_management.review_hooks import (
+    get_breadcrumb_module,
+    get_review_search_fields,
+)
 
 from ..forms import (
     DynamicTableInlineFormSetHelper,
@@ -74,13 +78,6 @@ DEFAULT_BREADCRUMB_MODULES = {
     "properties": {"label": "Properties", "url_name": "properties-dashboard"},
     "sources": {"label": "Sources", "url_name": "sources-explorer"},
     "utils": {"label": "Utilities", "url_name": "utils-dashboard"},
-    # Source-domain plugins render nested under the Sources explorer.
-    "waste_collection": {
-        "label": "Waste Collection",
-        "url_name": "wastecollection-explorer",
-        "parent_label": "Sources",
-        "parent_url_name": "sources-explorer",
-    },
     "greenhouses": {
         "label": "Greenhouses",
         "url_name": None,
@@ -109,7 +106,18 @@ def _get_breadcrumb_model(view):
 def _get_default_breadcrumb_module_config(model):
     if model is None:
         return None
-    return DEFAULT_BREADCRUMB_MODULES.get(model._meta.app_label)
+    config = DEFAULT_BREADCRUMB_MODULES.get(model._meta.app_label)
+    if config is not None:
+        return config
+    registered_config = get_breadcrumb_module(model._meta.app_label)
+    if registered_config is None:
+        return None
+    return {
+        "label": registered_config.label,
+        "url_name": registered_config.url_name,
+        "parent_label": registered_config.parent_label,
+        "parent_url_name": registered_config.parent_url_name,
+    }
 
 
 def _get_default_breadcrumb_module(model):
@@ -533,16 +541,9 @@ class ReviewDashboardView(LoginRequiredMixin, FilterDefaultsMixin, FilterView):
         except FieldDoesNotExist:
             pass
 
-        if (
-            model_class._meta.model_name == "collection"
-            and model_class._meta.app_label == "waste_collection"
-        ):
-            search_filters.extend(
-                [
-                    Q(catchment__name__icontains=search),
-                    Q(waste_category__name__icontains=search),
-                    Q(collection_system__name__icontains=search),
-                ]
+        for field_name in get_review_search_fields(model_class):
+            search_filters.append(
+                Q(**{f"{field_name}__icontains": search})
             )
 
         if not search_filters:


### PR DESCRIPTION
Starts the first roadmap slice for WS1-A by moving waste-collection review dashboard integration out of `utils.object_management` and into source-owned hooks.

Key shape:

```python
# lower layer owns contracts
register_review_context_enricher("app.model", fn)
register_review_search_fields("app.model", ["related__name"])
register_review_update_context("app.model", fn, context_key="domain_update")

# source app fills them in AppConfig.ready()
sources.waste_collection.review_hooks.register_review_hooks()
```

Waste collection now registers Collection/CPV review enrichers, collection search fields, update-context hints, and breadcrumb metadata from `sources.waste_collection`, while `utils.object_management` only calls the generic registry. Context enricher failures are isolated per plugin, and update-context hooks now own their response key so the API view no longer hardcodes the waste-collection-specific `collection_update` name. Waste collection explicitly keeps the existing public `collection_update` key.

## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Verification

- [x] Focused tests or checks were run.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed. Not applicable; no asset sources changed.
- [x] No secrets, raw data, or production-only configuration are included.

Commands run:

- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT --print-targets` → `manage.py check` passed
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- utils.object_management.tests.test_review_hooks` → failed before registry implementation, then passed
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- utils.object_management.tests.test_review_hooks.ReviewHookRegistryTests.test_context_enricher_errors_do_not_block_other_enrichers` → failed before exception isolation, then passed
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- utils.object_management.tests.test_review_hooks.ReviewHookRegistryTests.test_update_context_hook_is_resolved_by_model_label utils.object_management.tests.test_api_views.ReviewAPIViewsTests.test_review_context_uses_registered_update_context_key utils.object_management.tests.test_api_views.ReviewAPIViewsTests.test_review_context_exposes_collection_update_contract_for_owner_only` → failed before generic-key implementation, then passed
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- utils.object_management.tests.test_review_hooks sources.waste_collection.tests.test_apps utils.object_management.tests.test_api_views utils.object_management.tests.test_views` → 87 tests passed
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-compose /home/ubuntu/repos/BRIT run --rm web ruff check sources/waste_collection/review_hooks.py sources/waste_collection/apps.py sources/waste_collection/tests/test_apps.py utils/object_management/review_hooks.py utils/object_management/review_context.py utils/object_management/api_views.py utils/object_management/views.py utils/object_management/tests/test_api_views.py utils/object_management/tests/test_review_hooks.py` → passed
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-compose /home/ubuntu/repos/BRIT run --rm web ruff check utils/object_management/review_hooks.py utils/object_management/api_views.py utils/object_management/tests/test_review_hooks.py utils/object_management/tests/test_api_views.py sources/waste_collection/review_hooks.py` → passed

Runtime/browser evidence remains in the PR test-results comment.

Link to Devin session: https://app.devin.ai/sessions/a9e96bccc03b4989b10c04d356986665
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->