### PR TITLE
WS1-B: invert properties bibliography attribution

### DIFF
--- a/docs/02_developer_guide/architecture.md
+++ b/docs/02_developer_guide/architecture.md
@@ -35,6 +35,16 @@ This document provides a durable, high-level view of BRIT architecture. It is in
 - **Modular domains**
   Keep domain logic inside app boundaries.
 
+- **Layered imports**
+  Lower-level apps define generic contracts; higher-level/domain apps fill them in
+  through concrete models, serializers, or app-startup registration. Shared utilities
+  must not import source-domain or reference-data apps for optional domain features.
+
+- **Bibliography-backed attribution**
+  Models that expose `sources` relations own those `bibliography.Source` fields in their
+  concrete app. `utils.properties` provides numeric measurement helpers only and does
+  not define or serialize bibliography attribution.
+
 - **Reusable base abstractions**
   Shared object lifecycle, ownership, permissions, and export behavior are implemented centrally and reused across apps.
 
@@ -55,4 +65,4 @@ This document provides a durable, high-level view of BRIT architecture. It is in
 - **Detailed data flow**
   See [architecture/data_flow.md](architecture/data_flow.md).
 
-_Last updated: 2026-03-06_
+_Last updated: 2026-06-16_

--- a/docs/05_roadmap/README.md
+++ b/docs/05_roadmap/README.md
@@ -42,8 +42,8 @@ Non-test code only; test-code coupling is tracked separately in WS6.
 
 | # | Violation | Where | Fix direction |
 |---|---|---|---|
-| V1 | `utils.object_management` hardcodes `waste_collection.Collection` knowledge | `utils/object_management/api_views.py:182-233`, `views.py:78,536-546`, `review_context.py:66-345` | Review-context/search-field plugin hooks; domain registers enrichers (WS1-A) |
-| V2 | `utils.properties` imports `bibliography` | `utils/properties/models.py:8`, `serializers.py:3`; also `utils/forms.py:548` | Decide: promote `bibliography` to an explicit L0 dependency of properties, or invert via swappable source relation (WS1-B) |
+| V1 | Resolved: `utils.object_management` no longer hardcodes `waste_collection.Collection` knowledge | PR #179 moved review-context/search-field/update-context hooks behind source-owned registration | Keep domain-specific review context in source app hooks (WS1-A) |
+| V2 | `utils.properties` imports `bibliography` | `utils/properties/models.py:8`, `serializers.py:3`; also `utils/forms.py:548` | Invert attribution ownership: domains with bibliography-backed `sources` fields own those fields/serializers; shared utils infer form field models without importing bibliography (WS1-B) |
 | V3 | `utils.file_export` discovers `sources` plugins | `utils/file_export/registry_init.py` | Invert: source apps push exports into `export_registry` from their own `AppConfig.ready()` (WS1-C) |
 | V4 | `maps` imports `sources.registry` | `maps/urls.py:3`, `maps/tasks.py:11`, `maps/runtime_adapters.py:12`, `maps/management/commands/warm_geojson_cache.py` | Move the *contract* (map mounts, cache warmers, runtime compatibility) into `maps`; source apps register themselves (WS1-D) |
 | V5 | `maps` hardcodes domain dataset names | `maps/models.py:33-39` (`GIS_SOURCE_MODELS` incl. `WasteCollection`), legacy `GeoDataset.model_name` | Finish runtime-configuration migration, delete legacy name dispatch (WS1-D, overlaps #85) |
@@ -67,11 +67,13 @@ The single most important arc. Sub-items in implementation order:
    `review_context.py`/`api_views.py`/`views.py` into
    `sources/waste_collection/review_hooks.py`, registered in its `AppConfig.ready()`.
    Outcome: the review dashboard scales to any future domain without touching utils.
+   **Status:** completed in PR #179.
 2. **B. Properties/bibliography (V2).** `PropertyValue.sources` (M2M to
-   `bibliography.Source`) makes `utils.properties` depend on L1. Pragmatic decision:
-   declare `bibliography` a documented dependency of `utils.properties` and move both
-   into L0/L1 adjacency, OR extract the sources M2M into the domain models that need
-   attribution. Decide once, document in architecture.md, enforce.
+   `bibliography.Source`) makes `utils.properties` depend on L1. Decision:
+   bibliography-backed attribution belongs to the concrete domain models that need it.
+   `utils.properties` keeps numeric measurement contracts only, while shared source-form
+   helpers derive the source model from the form field instead of importing
+   `bibliography`.
 3. **C. Export registry inversion (V3).** Delete `utils/file_export/registry_init.py`;
    each source app calls `register_export(...)` in its own `ready()`. The
    `sources.contracts.SourceDomainExport` dataclass moves to

--- a/materials/serializers.py
+++ b/materials/serializers.py
@@ -89,6 +89,7 @@ class MaterialPropertyValueModelSerializer(
     )
     basis_component = ReadOnlyField(source="basis_component.name")
     analytical_method = StringRelatedField()
+    sources = SourceAbbreviationSerializer(many=True, read_only=True)
 
     class Meta:
         model = MaterialPropertyValue

--- a/materials/serializers.py
+++ b/materials/serializers.py
@@ -171,7 +171,7 @@ class SampleModelSerializer(ModelSerializer):
             "basis_component",
             "analytical_method",
             "unit",
-        )
+        ).prefetch_related("sources")
         return MaterialPropertyValueModelSerializer(
             queryset.order_by("property__name", "id"),
             many=True,

--- a/materials/tests/test_serializers.py
+++ b/materials/tests/test_serializers.py
@@ -158,6 +158,45 @@ class SampleSerializerTestCase(TestCase):
             "Dry Matter",
         )
 
+    def test_properties_prefetches_sources(self):
+        request = RequestFactory().get(
+            reverse("sample-detail", kwargs={"pk": self.sample.id})
+        )
+        first_value = self.sample.property_values.get(property__name="Dry Matter")
+        with mute_signals(post_save):
+            first_source = Source.objects.create(
+                title="First Property Source",
+                citation_key="FPS",
+            )
+            second_source = Source.objects.create(
+                title="Second Property Source",
+                citation_key="SPS",
+            )
+        first_value.sources.add(first_source)
+        second_property = MaterialProperty.objects.create(
+            name="Ash",
+            unit="%",
+            owner=self.owner,
+        )
+        second_value = MaterialPropertyValue.objects.create(
+            sample=self.sample,
+            property=second_property,
+            unit=first_value.unit,
+            average=Decimal("10.0"),
+            owner=self.owner,
+        )
+        second_value.sources.add(second_source)
+
+        serializer = SampleModelSerializer(context={"request": request})
+        with self.assertNumQueries(2):
+            data = serializer.get_properties(self.sample)
+
+        self.assertEqual(len(data), 2)
+        self.assertEqual(
+            {source["citation_key"] for prop in data for source in prop["sources"]},
+            {"FPS", "SPS"},
+        )
+
     def test_serializer_uses_shared_normalized_compositions(self):
         self.sample.compositions.all().delete()
         unit = Unit.objects.filter(name="%").first()

--- a/utils/forms.py
+++ b/utils/forms.py
@@ -544,8 +544,6 @@ class SourcesFieldMixin:
     """
 
     def __init__(self, *args, **kwargs):
-        # Import here to avoid circular imports
-        from bibliography.models import Source
         from utils.widgets import SourceListWidget
 
         # Capture data BEFORE calling super().__init__ (parent consumes it)
@@ -568,12 +566,15 @@ class SourcesFieldMixin:
         if "sources" not in self.fields:
             return  # Field not included in this form, skip mixin logic
 
+        sources_field = self.fields["sources"]
+        source_model = sources_field.queryset.model
+
         # Configure the sources field
-        self.fields["sources"].required = False  # Sources are optional
+        sources_field.required = False  # Sources are optional
 
         # Set widget if not already customized
-        if not isinstance(self.fields["sources"].widget, SourceListWidget):
-            self.fields["sources"].widget = SourceListWidget(
+        if not isinstance(sources_field.widget, SourceListWidget):
+            sources_field.widget = SourceListWidget(
                 autocomplete_url="source-autocomplete", label_field="label"
             )
 
@@ -593,6 +594,6 @@ class SourcesFieldMixin:
 
         # Set queryset to include all relevant sources (permission check in clean())
         if source_ids:
-            self.fields["sources"].queryset = Source.objects.filter(id__in=source_ids)
+            sources_field.queryset = source_model.objects.filter(id__in=source_ids)
         else:
-            self.fields["sources"].queryset = Source.objects.none()
+            sources_field.queryset = source_model.objects.none()

--- a/utils/properties/models.py
+++ b/utils/properties/models.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.db import models
 from django.db.models import Q
 
-from bibliography.models import Source
 from utils.object_management.models import NamedUserCreatedObject, get_default_owner
 from utils.properties.units import (
     UnitConversionError,
@@ -227,12 +226,6 @@ class PropertyValue(NumericMeasurementMixin, NamedUserCreatedObject):
     )
     average = models.FloatField()
     standard_deviation = models.FloatField(blank=True, null=True)
-    sources = models.ManyToManyField(
-        Source,
-        blank=True,
-        help_text="Sources or references for this property value.",
-    )
-
     class Meta:
         abstract = True
         ordering = ["property__name"]

--- a/utils/properties/serializers.py
+++ b/utils/properties/serializers.py
@@ -1,6 +1,5 @@
 from rest_framework.serializers import ModelSerializer, ReadOnlyField, Serializer
 
-from bibliography.serializers import SourceAbbreviationSerializer
 from utils.properties.models import (
     Property,
     PropertyValue,
@@ -14,7 +13,6 @@ class NumericMeasurementSerializerMixin(Serializer):
     average = ReadOnlyField(source="display_average")
     standard_deviation = ReadOnlyField(source="display_standard_deviation")
     unit = ReadOnlyField(source="measurement_unit_label")
-    sources = SourceAbbreviationSerializer(many=True, read_only=True)
 
 
 class UnitModelSerializer(ModelSerializer):

--- a/utils/properties/tests/test_layering.py
+++ b/utils/properties/tests/test_layering.py
@@ -1,0 +1,33 @@
+import ast
+from pathlib import Path
+
+from django.conf import settings
+from django.test import SimpleTestCase
+
+
+class PropertiesLayeringTests(SimpleTestCase):
+    def test_properties_and_shared_forms_do_not_import_bibliography(self):
+        checked_paths = [
+            Path("utils/properties/models.py"),
+            Path("utils/properties/serializers.py"),
+            Path("utils/forms.py"),
+        ]
+
+        for relative_path in checked_paths:
+            with self.subTest(path=str(relative_path)):
+                tree = ast.parse((settings.BASE_DIR / relative_path).read_text())
+                imported_modules = {
+                    module
+                    for node in ast.walk(tree)
+                    for module in _imported_modules(node)
+                }
+
+                self.assertNotIn("bibliography", imported_modules)
+
+
+def _imported_modules(node):
+    if isinstance(node, ast.Import):
+        return [alias.name.split(".", maxsplit=1)[0] for alias in node.names]
+    if isinstance(node, ast.ImportFrom) and node.module:
+        return [node.module.split(".", maxsplit=1)[0]]
+    return []


### PR DESCRIPTION
Continues the WS1 roadmap after #179 by resolving the `utils.properties` → `bibliography` dependency without promoting bibliography into the utility layer.

Decision implemented:

```python
# utils.properties owns numeric measurement contracts only
class PropertyValue(NumericMeasurementMixin, NamedUserCreatedObject):
    property = ForeignKey(Property)
    unit = ForeignKey(Unit)
    average = FloatField()

# concrete domain apps own bibliography attribution
class CollectionPropertyValue(PropertyValue):
    sources = ManyToManyField(bibliography.Source, ...)
```

Shared `SourcesFieldMixin` now derives the model from the form field queryset instead of importing `bibliography.Source`, so domain forms keep the same behavior while `utils` no longer reaches up into L1/reference data. The roadmap marks WS1-A/#179 complete and records the WS1-B attribution decision; `architecture.md` documents the durable boundary.

Follow-up from review: `SampleModelSerializer.get_properties()` now prefetches property-value `sources`, with a query-count regression proving multiple property values do not add per-row source queries.

## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Verification

- [x] Focused tests or checks were run.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed. Not applicable; no source JS/CSS/SCSS changed.
- [x] No secrets, raw data, or production-only configuration are included.

Commands run:

- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT --print-targets` → `manage.py check`
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- utils.properties.tests.test_layering.PropertiesLayeringTests.test_properties_and_shared_forms_do_not_import_bibliography` → failed before implementation, then passed
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-compose /home/ubuntu/repos/BRIT run --rm web python manage.py makemigrations --check --dry-run --settings=brit.settings.testrunner` → `No changes detected`
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- utils.properties.tests materials.tests.test_serializers materials.tests.test_forms maps.tests.test_forms sources.waste_collection.tests.test_forms` → 296 passed, 62 skipped
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- sources.waste_collection.tests.test_serializers` → 31 passed
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- materials.tests.test_serializers.SampleSerializerTestCase.test_properties_prefetches_sources` → passed
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- materials.tests.test_serializers` → 9 passed
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-compose /home/ubuntu/repos/BRIT run --rm web ruff check docs/05_roadmap/README.md docs/02_developer_guide/architecture.md utils/properties/models.py utils/properties/serializers.py utils/properties/tests/test_layering.py utils/forms.py materials/serializers.py` → passed
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-compose /home/ubuntu/repos/BRIT run --rm web ruff check materials/serializers.py materials/tests/test_serializers.py` → passed
- `git diff --check` → passed

Runtime UI verification is documented in the PR comment with screenshots and recording.

Link to Devin session: https://app.devin.ai/sessions/a9e96bccc03b4989b10c04d356986665
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->