### PR TITLE
Add Waste Atlas participation policy map

### DIFF
--- a/sources/waste_collection/tests/test_viewsets.py
+++ b/sources/waste_collection/tests/test_viewsets.py
@@ -2410,6 +2410,7 @@ class ConnectionRateViewSetTests(APITestCase):
             waste_category=cls.bio_category,
             collection_system=cls.d2d,
             valid_from=date(2024, 1, 1),
+            connection_type="MANDATORY",
         )
         cls.current_collection.predecessors.add(cls.previous_collection)
         CollectionPropertyValue.objects.create(
@@ -2439,6 +2440,23 @@ class ConnectionRateViewSetTests(APITestCase):
                     "connection_rate": 0.9,
                     "is_door_to_door": True,
                     "reporting_year": 2023,
+                }
+            ],
+        )
+
+    def test_connection_type_endpoint_returns_selected_collection_value(self):
+        response = self.client.get(
+            "/waste_collection/api/waste-atlas/connection-type/",
+            {"country": "DE", "year": 2024},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data,
+            [
+                {
+                    "catchment_id": self.catchment.id,
+                    "connection_type": "MANDATORY",
                 }
             ],
         )

--- a/sources/waste_collection/tests/test_waste_atlas_map_configs.py
+++ b/sources/waste_collection/tests/test_waste_atlas_map_configs.py
@@ -7,6 +7,13 @@ from sources.waste_collection.waste_atlas.map_configs import (
     MAP_CONFIGS,
     NO_DATA_COLOR,
 )
+from sources.waste_collection.waste_atlas.map_selection import (
+    MAP_SELECTION_THEME_ORDER,
+    MAP_SELECTION_WASTE_CATEGORY_OVERRIDES,
+    THEME_LABELS,
+    WASTE_ATLAS_MAP_SELECTIONS,
+)
+from sources.waste_collection.waste_atlas.pages import MAP_PAGES
 
 
 class WasteAtlasMapConfigTests(SimpleTestCase):
@@ -104,6 +111,67 @@ class WasteAtlasMapConfigTests(SimpleTestCase):
         self.assertIn("function findThemeOption(", script)
         self.assertIn("selectedThemeGroup", script)
         self.assertIn("data-theme-group", script)
+
+    def test_participation_policy_map_config_displays_connection_type(self):
+        config = MAP_CONFIGS["connection_type"]
+
+        self.assertEqual(config["title"], "Participation Policy")
+        self.assertEqual(
+            config["dataUrl"], "/waste_collection/api/waste-atlas/connection-type/"
+        )
+        self.assertEqual(config["dataField"], "connection_type")
+        self.assertEqual(config["legendTitle"], "Participation Policy")
+        self.assertEqual(config["fileBase"], "connection_type")
+        self.assertEqual(
+            [entry["value"] for entry in config["categories"]],
+            [
+                "MANDATORY",
+                "MANDATORY_WITH_HOME_COMPOSTER_EXCEPTION",
+                "VOLUNTARY",
+                "not_specified",
+            ],
+        )
+
+    def test_participation_policy_map_pages_match_connection_rate_scopes(self):
+        connection_rate_pages = {
+            page["region"]: page
+            for page in MAP_PAGES
+            if page["theme"] == "connection_rate"
+        }
+        connection_type_pages = {
+            page["region"]: page
+            for page in MAP_PAGES
+            if page["theme"] == "connection_type"
+        }
+
+        self.assertEqual(connection_type_pages.keys(), connection_rate_pages.keys())
+        self.assertEqual(
+            connection_type_pages["nrw"]["path"], "map/nrw/participation-policy/"
+        )
+        self.assertEqual(
+            connection_type_pages["nrw"]["name"],
+            "waste-atlas-nrw-participation-policy-map",
+        )
+        for page in connection_type_pages.values():
+            with self.subTest(region=page["region"]):
+                self.assertEqual(page["title"], "Participation Policy")
+                self.assertEqual(page["config_key"], "connection_type")
+
+    def test_participation_policy_map_is_available_as_biowaste_theme(self):
+        self.assertEqual(THEME_LABELS["connection_type"], "Participation Policy")
+        self.assertEqual(
+            MAP_SELECTION_WASTE_CATEGORY_OVERRIDES["connection_type"], "biowaste"
+        )
+        self.assertLess(
+            MAP_SELECTION_THEME_ORDER["connection_rate"],
+            MAP_SELECTION_THEME_ORDER["connection_type"],
+        )
+
+        for map_set in ("DE", "DE-NW", "DE-BW-RP", "ES-CT"):
+            with self.subTest(map_set=map_set):
+                self.assertIn(
+                    "connection_type", WASTE_ATLAS_MAP_SELECTIONS[map_set]["themes"]
+                )
 
     def _forbidden_unit_tokens(self, legend_title):
         for unit, forbidden_tokens in self.UNIT_LABEL_FORBIDDEN_TOKENS.items():

--- a/sources/waste_collection/waste_atlas/map_configs.py
+++ b/sources/waste_collection/waste_atlas/map_configs.py
@@ -1043,6 +1043,37 @@ MAP_CONFIGS = {
         "quartileColors": ["#d1e7e6", "#7fcce9", "#0090cb", "#00608e"],
         "quartilePreserveClasses": ["no_d2d"],
     },
+    "connection_type": {
+        "title": "Participation Policy",
+        "dataUrl": "/waste_collection/api/waste-atlas/connection-type/",
+        "dataField": "connection_type",
+        "categories": [
+            {
+                "value": "MANDATORY",
+                "label": "Mandatory",
+                "color": "#00608e",
+            },
+            {
+                "value": "MANDATORY_WITH_HOME_COMPOSTER_EXCEPTION",
+                "label": "Mandatory, except home composters",
+                "color": "#0090cb",
+            },
+            {
+                "value": "VOLUNTARY",
+                "label": "Voluntary",
+                "color": "#7fcce9",
+            },
+            {
+                "value": "not_specified",
+                "label": "Not specified",
+                "color": "#d1e7e6",
+            },
+        ],
+        "noDataColor": NO_DATA_COLOR,
+        "noDataLabel": "No data",
+        "legendTitle": "Participation Policy",
+        "fileBase": "connection_type",
+    },
     "denmark_collection_support": {
         "title": "Accepted materials for biowaste collection aids",
         "dataUrl": "/waste_collection/api/waste-atlas/regular-plastic-collection-support/",

--- a/sources/waste_collection/waste_atlas/map_selection.py
+++ b/sources/waste_collection/waste_atlas/map_selection.py
@@ -31,6 +31,7 @@ THEME_LABELS = {
     "combined_fee_system": "Combined fees",
     "combined_frequency": "Combined schedule",
     "connection_rate": "Connection rate",
+    "connection_type": "Participation Policy",
     "food_waste_category": "Accepted food waste",
     "green_waste_collection_amount": "Green waste amount",
     "green_waste_collection_system_count": "Green waste system count",
@@ -111,6 +112,7 @@ MAP_SELECTION_THEME_ORDER = {
     "waste_ratio": 640,
     "organic_waste_ratio": 650,
     "connection_rate": 700,
+    "connection_type": 710,
 }
 
 MAP_SELECTION_WASTE_CATEGORIES = {
@@ -145,6 +147,7 @@ MAP_SELECTION_WASTE_CATEGORY_PREFIXES = (
 MAP_SELECTION_WASTE_CATEGORY_OVERRIDES = {
     "collection_system": "biowaste",
     "connection_rate": "biowaste",
+    "connection_type": "biowaste",
     "food_waste_category": "biowaste",
     "paper_bags": "biowaste",
     "plastic_bags": "biowaste",

--- a/sources/waste_collection/waste_atlas/pages.py
+++ b/sources/waste_collection/waste_atlas/pages.py
@@ -611,6 +611,13 @@ MAP_PAGES = [
     ),
     _page(
         "generic",
+        "connection_type",
+        "Participation Policy",
+        "map/participation-policy/",
+        "waste-atlas-participation-policy-map",
+    ),
+    _page(
+        "generic",
         "food_waste_category",
         "Accepted food-waste categories in biowaste",
         "map/food-waste-category/",
@@ -812,6 +819,13 @@ MAP_PAGES = [
         "Connection rates for door-to-door biowaste collection",
         "map/germany/connection-rate/",
         "waste-atlas-germany-connection-rate-map",
+    ),
+    _page(
+        "germany",
+        "connection_type",
+        "Participation Policy",
+        "map/germany/participation-policy/",
+        "waste-atlas-germany-participation-policy-map",
     ),
     _page(
         "germany",
@@ -1030,6 +1044,13 @@ MAP_PAGES = [
         "Connection rates for door-to-door biowaste collection",
         "map/nrw/connection-rate/",
         "waste-atlas-nrw-connection-rate-map",
+    ),
+    _page(
+        "nrw",
+        "connection_type",
+        "Participation Policy",
+        "map/nrw/participation-policy/",
+        "waste-atlas-nrw-participation-policy-map",
     ),
     _page(
         "nrw",
@@ -1286,6 +1307,13 @@ MAP_PAGES = [
     ),
     _page(
         "catalonia",
+        "connection_type",
+        "Participation Policy",
+        "map/catalonia/participation-policy/",
+        "waste-atlas-catalonia-participation-policy-map",
+    ),
+    _page(
+        "catalonia",
         "food_waste_category",
         "Accepted food-waste categories in biowaste",
         "map/catalonia/food-waste-category/",
@@ -1515,6 +1543,13 @@ MAP_PAGES = [
         "Connection rates for door-to-door biowaste collection",
         "map/bw-rp/connection-rate/",
         "waste-atlas-bw-rp-connection-rate-map",
+    ),
+    _page(
+        "bw_rp",
+        "connection_type",
+        "Participation Policy",
+        "map/bw-rp/participation-policy/",
+        "waste-atlas-bw-rp-participation-policy-map",
     ),
     _page(
         "bw_rp",

--- a/sources/waste_collection/waste_atlas/router.py
+++ b/sources/waste_collection/waste_atlas/router.py
@@ -26,6 +26,7 @@ from .viewsets import (
     CombinedFeeSystemViewSet,
     CombinedFrequencyTypeViewSet,
     ConnectionRateViewSet,
+    ConnectionTypeViewSet,
     FoodWasteCategoryViewSet,
     GreenWasteCollectionAmountViewSet,
     GreenWasteCollectionSystemCountViewSet,
@@ -115,6 +116,11 @@ router.register(
     "connection-rate",
     ConnectionRateViewSet,
     basename="api-waste-atlas-connection-rate",
+)
+router.register(
+    "connection-type",
+    ConnectionTypeViewSet,
+    basename="api-waste-atlas-connection-type",
 )
 router.register(
     "food-waste-category",

--- a/sources/waste_collection/waste_atlas/serializers.py
+++ b/sources/waste_collection/waste_atlas/serializers.py
@@ -107,6 +107,11 @@ class CatchmentConnectionRateSerializer(serializers.Serializer):
         return data
 
 
+class CatchmentConnectionTypeSerializer(serializers.Serializer):
+    catchment_id = serializers.IntegerField()
+    connection_type = serializers.CharField(allow_blank=True, allow_null=True)
+
+
 class CatchmentFoodWasteCategorySerializer(serializers.Serializer):
     """Flat JSON serializer for allowed food waste in biowaste (Karte 4)."""
 

--- a/sources/waste_collection/waste_atlas/viewsets.py
+++ b/sources/waste_collection/waste_atlas/viewsets.py
@@ -53,6 +53,7 @@ from .serializers import (
     CatchmentCombinedFeeSystemSerializer,
     CatchmentCombinedFrequencySerializer,
     CatchmentConnectionRateSerializer,
+    CatchmentConnectionTypeSerializer,
     CatchmentFeeSystemSerializer,
     CatchmentFoodWasteCategorySerializer,
     CatchmentFrequencyTypeSerializer,
@@ -2731,6 +2732,27 @@ class ConnectionRateViewSet(WasteAtlasViewSet):
             )
 
         serializer = CatchmentConnectionRateSerializer(data, many=True)
+        return Response(serializer.data)
+
+
+class ConnectionTypeViewSet(WasteAtlasViewSet):
+    permission_classes = [permissions.AllowAny]
+
+    def list(self, request):
+        country, year = _parse_country_year(request)
+        nuts_prefixes = _parse_nuts_prefixes(request)
+
+        data = [
+            {"catchment_id": cid, "connection_type": row["connection_type"]}
+            for cid, row in _select_primary_collections(
+                country,
+                year,
+                ["Biowaste", "Food waste"],
+                nuts_prefixes,
+                extra_fields=("connection_type",),
+            ).items()
+        ]
+        serializer = CatchmentConnectionTypeSerializer(data, many=True)
         return Response(serializer.data)
 
 


### PR DESCRIPTION
## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Summary

Adds a Waste Atlas `connection_type` choropleth map titled `Participation Policy`. The new map mirrors the existing Connection rate scopes (`generic`, Germany, NRW, Catalonia, BW/RP), uses `/waste_collection/api/waste-atlas/connection-type/`, and displays the selected primary biowaste/food-waste collection’s `Collection.connection_type` value.

Map data flow:

```text
ConnectionTypeViewSet
  -> _select_primary_collections(..., ["Biowaste", "Food waste"], extra_fields=("connection_type",))
  -> [{ catchment_id, connection_type }]

MAP_CONFIGS["connection_type"]
  dataField = "connection_type"
  legendTitle/title = "Participation Policy"
```

## Verification

- [x] Focused tests or checks were run.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed. (Not applicable: no JS/CSS/SCSS changed.)
- [x] No secrets, raw data, or production-only configuration are included.

Commands run:

- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT --print-targets`
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- sources.waste_collection.tests.test_waste_atlas_map_configs` (red before implementation, green after)
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- sources.waste_collection.tests.test_waste_atlas_map_configs sources.waste_collection.tests.test_viewsets.ConnectionRateViewSetTests`
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-compose /home/ubuntu/repos/BRIT run --rm web ruff check sources/waste_collection/tests/test_waste_atlas_map_configs.py sources/waste_collection/tests/test_viewsets.py sources/waste_collection/waste_atlas/map_configs.py sources/waste_collection/waste_atlas/map_selection.py sources/waste_collection/waste_atlas/pages.py sources/waste_collection/waste_atlas/router.py sources/waste_collection/waste_atlas/serializers.py sources/waste_collection/waste_atlas/viewsets.py`
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-compose /home/ubuntu/repos/BRIT run --rm web ruff format --check sources/waste_collection/tests/test_waste_atlas_map_configs.py sources/waste_collection/tests/test_viewsets.py sources/waste_collection/waste_atlas/map_configs.py sources/waste_collection/waste_atlas/map_selection.py sources/waste_collection/waste_atlas/pages.py sources/waste_collection/waste_atlas/router.py sources/waste_collection/waste_atlas/serializers.py sources/waste_collection/waste_atlas/viewsets.py`
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT`

Link to Devin session: https://app.devin.ai/sessions/19bf0a553a52421093c1284a4dc45372
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->