### PR TITLE
Classify no biowaste collection in Participation Policy map

### DIFF
--- a/sources/waste_collection/tests/test_viewsets.py
+++ b/sources/waste_collection/tests/test_viewsets.py
@@ -2534,6 +2534,7 @@ class WasteAtlasPrimarySelectionTests(APITestCase):
             "collection_system": "/waste_collection/api/waste-atlas/collection-system/",
             "paper_bags": "/waste_collection/api/waste-atlas/paper-bags/",
             "connection_rate": "/waste_collection/api/waste-atlas/connection-rate/",
+            "connection_type": "/waste_collection/api/waste-atlas/connection-type/",
         }
         responses = {
             name: self.client.get(endpoint, {"country": "DE", "year": 2024})
@@ -2552,6 +2553,10 @@ class WasteAtlasPrimarySelectionTests(APITestCase):
         }
         rate_by_catchment = {
             row["catchment_id"]: row for row in responses["connection_rate"].data
+        }
+        connection_type_by_catchment = {
+            row["catchment_id"]: row["connection_type"]
+            for row in responses["connection_type"].data
         }
 
         d2d_catchment_ids = {
@@ -2576,6 +2581,10 @@ class WasteAtlasPrimarySelectionTests(APITestCase):
         )
         self.assertFalse(
             rate_by_catchment[self.no_collection_catchment.id]["is_door_to_door"]
+        )
+        self.assertEqual(
+            connection_type_by_catchment[self.no_collection_catchment.id],
+            "no_bio_collection",
         )
 
     def test_primary_selection_query_count_is_bounded(self):

--- a/sources/waste_collection/tests/test_waste_atlas_map_configs.py
+++ b/sources/waste_collection/tests/test_waste_atlas_map_configs.py
@@ -125,11 +125,20 @@ class WasteAtlasMapConfigTests(SimpleTestCase):
         self.assertEqual(
             [entry["value"] for entry in config["categories"]],
             [
+                "no_bio_collection",
                 "MANDATORY",
                 "MANDATORY_WITH_HOME_COMPOSTER_EXCEPTION",
                 "VOLUNTARY",
                 "not_specified",
             ],
+        )
+        self.assertEqual(
+            config["categories"][0],
+            {
+                "value": "no_bio_collection",
+                "label": "No separate biowaste collection",
+                "color": BIOWASTE_NO_COLLECTION_COLOR,
+            },
         )
 
     def test_participation_policy_map_pages_match_connection_rate_scopes(self):

--- a/sources/waste_collection/waste_atlas/map_configs.py
+++ b/sources/waste_collection/waste_atlas/map_configs.py
@@ -1049,6 +1049,11 @@ MAP_CONFIGS = {
         "dataField": "connection_type",
         "categories": [
             {
+                "value": "no_bio_collection",
+                "label": "No separate biowaste collection",
+                "color": BIOWASTE_NO_COLLECTION_COLOR,
+            },
+            {
                 "value": "MANDATORY",
                 "label": "Mandatory",
                 "color": "#00608e",

--- a/sources/waste_collection/waste_atlas/viewsets.py
+++ b/sources/waste_collection/waste_atlas/viewsets.py
@@ -2742,16 +2742,20 @@ class ConnectionTypeViewSet(WasteAtlasViewSet):
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
 
-        data = [
-            {"catchment_id": cid, "connection_type": row["connection_type"]}
-            for cid, row in _select_primary_collections(
-                country,
-                year,
-                ["Biowaste", "Food waste"],
-                nuts_prefixes,
-                extra_fields=("connection_type",),
-            ).items()
-        ]
+        data = []
+        for cid, row in _select_primary_collections(
+            country,
+            year,
+            ["Biowaste", "Food waste"],
+            nuts_prefixes,
+            extra_fields=("connection_type",),
+        ).items():
+            value = (
+                "no_bio_collection"
+                if row["collection_system"] == "No separate collection"
+                else row["connection_type"]
+            )
+            data.append({"catchment_id": cid, "connection_type": value})
         serializer = CatchmentConnectionTypeSerializer(data, many=True)
         return Response(serializer.data)
 


### PR DESCRIPTION
## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Summary

Participation Policy now treats primary `No separate collection` biowaste rows as a dedicated map class instead of falling through to generic no-data styling:

```python
connection_type = "no_bio_collection" if collection_system == "No separate collection" else row["connection_type"]
```

The map config adds the matching yellow `No separate biowaste collection` category, using the same no-collection color as the connection-rate map.

## Verification

- [x] Focused tests or checks were run.
  - `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- sources.waste_collection.tests.test_waste_atlas_map_configs.WasteAtlasMapConfigTests.test_participation_policy_map_config_displays_connection_type sources.waste_collection.tests.test_viewsets.WasteAtlasPrimarySelectionTests.test_primary_selection_is_consistent_across_map_endpoints` — passed
  - `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT` — passed, 1769 tests, 379 skipped
  - `/home/ubuntu/BRIT-ops/scripts/brit-worktree-compose /home/ubuntu/repos/BRIT run --rm web ruff check sources/waste_collection/tests/test_waste_atlas_map_configs.py sources/waste_collection/tests/test_viewsets.py sources/waste_collection/waste_atlas/map_configs.py sources/waste_collection/waste_atlas/viewsets.py` — passed
  - `/home/ubuntu/BRIT-ops/scripts/brit-worktree-compose /home/ubuntu/repos/BRIT run --rm web ruff format --check sources/waste_collection/tests/test_waste_atlas_map_configs.py sources/waste_collection/tests/test_viewsets.py sources/waste_collection/waste_atlas/map_configs.py sources/waste_collection/waste_atlas/viewsets.py` — passed
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed. Not applicable: no JS/CSS/SCSS changed.
- [x] No secrets, raw data, or production-only configuration are included.

Link to Devin session: https://app.devin.ai/sessions/19bf0a553a52421093c1284a4dc45372
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->