### PR TITLE
Add legacy collection update MCP route

### DIFF
--- a/sources/waste_collection/tests/test_viewsets.py
+++ b/sources/waste_collection/tests/test_viewsets.py
@@ -1666,6 +1666,38 @@ class CollectionMutationApiTestCase(APITestCase):
             ).exists()
         )
 
+    def test_update_collection_legacy_endpoint_alias_enriches_existing_collection(self):
+        self.client.force_login(self.owner)
+
+        response = self.client.post(
+            reverse(
+                "api-waste-collection-update-collection",
+                kwargs={"pk": self.private_predecessor.pk},
+            ),
+            {
+                "expected_catchment": str(self.private_predecessor.catchment),
+                "expected_waste_category": str(
+                    self.private_predecessor.effective_waste_category
+                ),
+                "expected_collection_system": str(
+                    self.private_predecessor.collection_system
+                ),
+                "expected_publication_status": self.private_predecessor.publication_status,
+                "expected_valid_from": self.private_predecessor.valid_from.isoformat(),
+                "description": "updated through legacy MCP alias",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data["updated"])
+
+        self.private_predecessor.refresh_from_db()
+        self.assertEqual(
+            self.private_predecessor.description,
+            "updated through legacy MCP alias",
+        )
+
     def test_update_endpoint_replaces_sources_when_provided(self):
         self.client.force_login(self.owner)
         stale_source = Source.objects.create(

--- a/sources/waste_collection/viewsets.py
+++ b/sources/waste_collection/viewsets.py
@@ -838,6 +838,16 @@ class CollectionViewSet(CachedGeoJSONMixin, UserCreatedObjectViewSet):
         )
 
     @action(
+        detail=True,
+        methods=["post"],
+        permission_classes=[permissions.IsAuthenticated],
+        url_path="update_collection",
+        url_name="update-collection",
+    )
+    def update_collection_legacy(self, request, pk=None):
+        return self.update_collection(request, pk=pk)
+
+    @action(
         detail=False,
         methods=["get"],
         permission_classes=[permissions.AllowAny],


### PR DESCRIPTION
## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

Adds a compatibility alias for the guarded collection mutation endpoint:

```text
POST /waste_collection/api/collection/<id>/update_collection/
  -> CollectionViewSet.update_collection(...)
```

This keeps MCP clients that address the DRF action by method name compatible while preserving the preferred `/update/` route.

## Verification

- [x] Focused tests or checks were run.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed.
- [x] No secrets, raw data, or production-only configuration are included.

Commands run:

```bash
/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT --print-targets
/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- sources.waste_collection.tests.test_viewsets.CollectionMutationApiTestCase.test_update_collection_legacy_endpoint_alias_enriches_existing_collection
/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT
uv run ruff check sources/waste_collection/viewsets.py sources/waste_collection/tests/test_viewsets.py
```

Link to Devin session: https://app.devin.ai/sessions/7853d7fb14e44a47a7eed08c1d579b0d
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->