### PR TITLE
Fix collection connection type export

### DIFF
--- a/brit/celery.py
+++ b/brit/celery.py
@@ -2,7 +2,7 @@ import os
 
 from celery import Celery
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "brit.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "brit.settings.local")
 app = Celery("brit")
 app.config_from_object("django.conf:settings", namespace="CELERY")
 app.autodiscover_tasks()

--- a/brit/settings/local.py
+++ b/brit/settings/local.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from pathlib import Path
 
 from .settings import *
 
@@ -8,6 +9,10 @@ SITE_ID = 1
 DEBUG = True
 
 ALLOWED_HOSTS = ["localhost", "127.0.0.1", "host.docker.internal", "testserver"]
+
+MEDIA_ROOT = Path(os.environ.get("MEDIA_ROOT", BASE_DIR / "media"))
+MEDIA_URL = "/media/"
+FILE_EXPORT_USE_LOCAL_STORAGE = True
 
 # Only install debug toolbar if not running tests
 TESTING = "test" in sys.argv

--- a/brit/settings/testrunner.py
+++ b/brit/settings/testrunner.py
@@ -64,6 +64,7 @@ STORAGES["staticfiles"] = {
 MEDIA_URL = "/media/"
 AWS_STORAGE_BUCKET_NAME = "tests"
 AWS_S3_CUSTOM_DOMAIN = "tests.invalid"
+FILE_EXPORT_USE_LOCAL_STORAGE = True
 
 COOKIE_CONSENT_ENABLED = False
 

--- a/brit/tests/test_celery.py
+++ b/brit/tests/test_celery.py
@@ -1,0 +1,32 @@
+import subprocess
+import sys
+from importlib import import_module
+
+from django.test import SimpleTestCase
+
+
+class CelerySettingsTests(SimpleTestCase):
+    def test_celery_defaults_to_local_settings_without_env_override(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import os; "
+                    "os.environ.pop('DJANGO_SETTINGS_MODULE', None); "
+                    "import brit.celery; "
+                    "print(os.environ['DJANGO_SETTINGS_MODULE'])"
+                ),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.stdout.strip(), "brit.settings.local")
+
+    def test_local_settings_use_local_file_export_storage(self):
+        local_settings = import_module("brit.settings.local")
+
+        self.assertIs(local_settings.FILE_EXPORT_USE_LOCAL_STORAGE, True)
+        self.assertEqual(local_settings.MEDIA_URL, "/media/")

--- a/sources/waste_collection/serializers.py
+++ b/sources/waste_collection/serializers.py
@@ -509,7 +509,7 @@ class CollectionFlatSerializer(serializers.ModelSerializer):
 
     @staticmethod
     def get_connection_type(obj):
-        return obj.connection_type or "not_specified"
+        return obj.connection_type
 
     @staticmethod
     def get_flyer_urls(obj):

--- a/sources/waste_collection/serializers.py
+++ b/sources/waste_collection/serializers.py
@@ -446,7 +446,7 @@ class CollectionFlatSerializer(serializers.ModelSerializer):
     required_bin_capacity_reference = serializers.CharField(
         required=False, allow_null=True
     )
-    connection_type = serializers.CharField(required=False, allow_null=True)
+    connection_type = serializers.SerializerMethodField(label="Connection type")
     access_control_bp = serializers.BooleanField(required=False, allow_null=True)
     access_control_pap = serializers.BooleanField(required=False, allow_null=True)
     comments = serializers.SerializerMethodField(source="description", label="Comments")
@@ -506,6 +506,10 @@ class CollectionFlatSerializer(serializers.ModelSerializer):
     def get_waste_category(obj):
         category = obj.effective_waste_category
         return str(category) if category else ""
+
+    @staticmethod
+    def get_connection_type(obj):
+        return obj.connection_type or "not_specified"
 
     @staticmethod
     def get_flyer_urls(obj):

--- a/sources/waste_collection/tests/test_serializers.py
+++ b/sources/waste_collection/tests/test_serializers.py
@@ -28,6 +28,7 @@ from ..serializers import (
     CollectionFrequencyMutationSerializer,
     CollectionImportRecordSerializer,
     CollectionModelSerializer,
+    CollectionResearchSerializer,
 )
 
 
@@ -350,21 +351,32 @@ class CollectionFlatSerializerTestCase(TestCase):
         }
         self.assertTrue(static_keys.issubset(set(serializer.data.keys())))
 
-    def test_connection_type_serializes_choice_or_not_specified(self):
+    def test_connection_type_serializes_stored_values(self):
         self.collection_nuts.connection_type = "MANDATORY"
         self.collection_nuts.save(update_fields=["connection_type"])
         serializer = CollectionFlatSerializer(self.collection_nuts)
         self.assertEqual(serializer.data["connection_type"], "MANDATORY")
 
-        self.collection_nuts.connection_type = None
+        self.collection_nuts.connection_type = "not_specified"
         self.collection_nuts.save(update_fields=["connection_type"])
         serializer = CollectionFlatSerializer(self.collection_nuts)
         self.assertEqual(serializer.data["connection_type"], "not_specified")
 
+        self.collection_nuts.connection_type = None
+        self.collection_nuts.save(update_fields=["connection_type"])
+        serializer = CollectionFlatSerializer(self.collection_nuts)
+        self.assertIsNone(serializer.data["connection_type"])
+
         self.collection_nuts.connection_type = ""
         self.collection_nuts.save(update_fields=["connection_type"])
         serializer = CollectionFlatSerializer(self.collection_nuts)
-        self.assertEqual(serializer.data["connection_type"], "not_specified")
+        self.assertEqual(serializer.data["connection_type"], "")
+
+    def test_research_serializer_preserves_unset_connection_type(self):
+        self.collection_nuts.connection_type = None
+        self.collection_nuts.save(update_fields=["connection_type"])
+        serializer = CollectionResearchSerializer(self.collection_nuts)
+        self.assertIsNone(serializer.data["connection_type"])
 
     def test_required_bin_capacity_field_label(self):
         serializer = CollectionFlatSerializer(self.collection_nuts)

--- a/sources/waste_collection/tests/test_serializers.py
+++ b/sources/waste_collection/tests/test_serializers.py
@@ -350,6 +350,22 @@ class CollectionFlatSerializerTestCase(TestCase):
         }
         self.assertTrue(static_keys.issubset(set(serializer.data.keys())))
 
+    def test_connection_type_serializes_choice_or_not_specified(self):
+        self.collection_nuts.connection_type = "MANDATORY"
+        self.collection_nuts.save(update_fields=["connection_type"])
+        serializer = CollectionFlatSerializer(self.collection_nuts)
+        self.assertEqual(serializer.data["connection_type"], "MANDATORY")
+
+        self.collection_nuts.connection_type = None
+        self.collection_nuts.save(update_fields=["connection_type"])
+        serializer = CollectionFlatSerializer(self.collection_nuts)
+        self.assertEqual(serializer.data["connection_type"], "not_specified")
+
+        self.collection_nuts.connection_type = ""
+        self.collection_nuts.save(update_fields=["connection_type"])
+        serializer = CollectionFlatSerializer(self.collection_nuts)
+        self.assertEqual(serializer.data["connection_type"], "not_specified")
+
     def test_required_bin_capacity_field_label(self):
         serializer = CollectionFlatSerializer(self.collection_nuts)
         self.assertEqual(

--- a/sources/waste_collection/tests/test_views.py
+++ b/sources/waste_collection/tests/test_views.py
@@ -6211,13 +6211,14 @@ class CollectionCSVRendererTestCase(TestCase):
         catchment = CollectionCatchment.objects.create(
             name="Test catchment", region=nuts.region_ptr
         )
-        for i in range(1, 3):
+        for i, connection_type in enumerate(["MANDATORY", "not_specified"], start=1):
             collection = Collection.objects.create(
                 name=f"collection{i}",
                 catchment=catchment,
                 collector=Collector.objects.create(name=f"collector{1}"),
                 collection_system=CollectionSystem.objects.create(name="Test system"),
                 waste_category=waste_category,
+                connection_type=connection_type,
                 fee_system=FeeSystem.objects.create(name="Fixed fee"),
                 frequency=frequency,
                 valid_from=date(2020, 1, 1),

--- a/sources/waste_collection/tests/test_views.py
+++ b/sources/waste_collection/tests/test_views.py
@@ -6262,16 +6262,14 @@ class CollectionCSVRendererTestCase(TestCase):
         renderer.render(self.file, self.content)
         self.file.seek(0)
         reader = csv.DictReader(codecs.getreader("utf-8")(self.file), delimiter="\t")
-        valid_labels = [
-            "Compulsory",
-            "Voluntary",
-            "Mandatory",
-            "Mandatory with exception for home composters",
-            "Not specified",
-            "",
+        valid_values = [
+            "MANDATORY",
+            "MANDATORY_WITH_HOME_COMPOSTER_EXCEPTION",
+            "VOLUNTARY",
+            "not_specified",
         ]
         for row in reader:
-            self.assertIn(row["Connection type"], valid_labels)
+            self.assertIn(row["Connection type"], valid_values)
 
     def test_allowed_materials_formatted_as_comma_separated_list_in_one_field(self):
         renderer = CollectionCSVRenderer()

--- a/sources/waste_collection/tests/test_views.py
+++ b/sources/waste_collection/tests/test_views.py
@@ -4192,7 +4192,6 @@ class WasteAtlasMapViewsTestCase(TestCase):
             reverse("waste-atlas-biowaste-frequency-map"),
         )
 
-
     def test_selector_includes_generic_biowaste_themes_for_sweden_from_nrw_context(
         self,
     ):

--- a/utils/file_export/storages.py
+++ b/utils/file_export/storages.py
@@ -1,4 +1,7 @@
+from pathlib import Path
+
 from django.conf import settings
+from django.core.files.storage import FileSystemStorage
 from storages.backends.s3boto3 import S3Boto3Storage
 
 
@@ -7,9 +10,20 @@ class TempUserFileDownloadStorage(S3Boto3Storage):
     location = "tmp"
 
 
+def get_file_export_storage():
+    if getattr(settings, "FILE_EXPORT_USE_LOCAL_STORAGE", False):
+        location = Path(settings.MEDIA_ROOT) / "tmp"
+        location.mkdir(parents=True, exist_ok=True)
+        return FileSystemStorage(
+            location=location,
+            base_url=f"{settings.MEDIA_URL.rstrip('/')}/tmp/",
+        )
+    return TempUserFileDownloadStorage()
+
+
 def write_file_for_download(file_name, data, renderer_class):
-    storage = TempUserFileDownloadStorage()
+    storage = get_file_export_storage()
     renderer = renderer_class()
-    with storage.open(file_name, "w") as file:
+    with storage.open(file_name, "wb") as file:
         renderer.render(file, data)
     return storage.url(file_name)

--- a/utils/file_export/tests/test_storages.py
+++ b/utils/file_export/tests/test_storages.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from django.test import SimpleTestCase, override_settings
+
+from utils.file_export.storages import write_file_for_download
+
+
+class BytesRenderer:
+    def render(self, file, data):
+        file.write(data)
+
+
+class FileExportStorageTests(SimpleTestCase):
+    def test_write_file_for_download_uses_local_storage_when_configured(self):
+        with TemporaryDirectory() as tmpdir:
+            with override_settings(
+                FILE_EXPORT_USE_LOCAL_STORAGE=True,
+                MEDIA_ROOT=tmpdir,
+                MEDIA_URL="/media/",
+            ):
+                url = write_file_for_download(
+                    "export.csv",
+                    b"header\nvalue\n",
+                    BytesRenderer,
+                )
+
+            self.assertEqual(url, "/media/tmp/export.csv")
+            self.assertEqual(
+                Path(tmpdir, "tmp", "export.csv").read_bytes(),
+                b"header\nvalue\n",
+            )


### PR DESCRIPTION
## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Summary

Fixes #191 by making `CollectionFlatSerializer` export the stored `connection_type` value for each row instead of dropping populated values to `None`/empty cells.

```python
connection_type = obj.connection_type
```

This preserves stored enum values such as `MANDATORY`, `MANDATORY_WITH_HOME_COMPOSTER_EXCEPTION`, `VOLUNTARY`, and explicit `not_specified`. Unset model values remain unset so serializers that inherit from `CollectionFlatSerializer`, including the research API serializer, keep distinguishing “never set” from explicit `not_specified`.

Also fixes the missing local export download icon: the icon did not appear because the async export never reached `SUCCESS` in local/dev. The normal celery worker defaulted to base `brit.settings` instead of local settings, and file exports always used S3-backed temp storage even when local/dev had no AWS credentials. Local/test exports now use filesystem-backed temp downloads under `/media/tmp/`, while production continues using the S3 storage path unless local storage is explicitly enabled.

![Download icon appears after local export completes](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNzRiYTQ4YjgzNWEwNDE2OGE3OGU0MzEyODk4Nzg0MWQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNzRiYTQ4YjgzNWEwNDE2OGE3OGU0MzEyODk4Nzg0MWQvYWFiYWFkNmItNTMwNy00ZmVlLWI0MTItMDY4OGFhMGI1ODVlIiwiaWF0IjoxNzgyMjEwNDc5LCJleHAiOjE3ODI4MTUyNzksImZpbGVuYW1lIjoiZmluYWxfZG93bmxvYWRfaWNvbl91aS5wbmcifQ.Jh4jgfN8-l2oy2pFenso9bQI6Uf4TcLzk4tBzkDfcOQ)

## Verification

- [x] Focused tests or checks were run.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed.
- [x] No secrets, raw data, or production-only configuration are included.

Ran:
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT --print-targets`
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT` (red before connection-type fix)
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- sources.waste_collection.tests.test_serializers`
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- sources.waste_collection.tests.test_serializers sources.waste_collection.tests.test_views.CollectionCSVRendererTestCase`
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- brit.tests.test_celery utils.file_export.tests.test_storages` (red before download-icon/local-export fix; green after)
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- utils.file_export.tests brit.tests.test_celery sources.waste_collection.tests.test_serializers sources.waste_collection.tests.test_views.CollectionCSVRendererTestCase` (105 tests passed)
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-compose /home/ubuntu/repos/BRIT exec -T web ruff check brit/celery.py brit/settings/local.py brit/settings/testrunner.py utils/file_export/storages.py brit/tests/test_celery.py utils/file_export/tests/test_storages.py`
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-compose /home/ubuntu/repos/BRIT exec -T web ruff format --check brit/celery.py brit/settings/local.py brit/settings/testrunner.py utils/file_export/storages.py brit/tests/test_celery.py utils/file_export/tests/test_storages.py`
- Runtime: restarted local web/celery, exported the seeded published collection list to CSV through the UI, confirmed the modal reached `Download CSV` with the download icon and the exported CSV contained one `Connection type` column with `MANDATORY` and `not_specified`.

Link to Devin session: https://app.devin.ai/sessions/223b208e36c547929337df93ec1e18c6
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->