### PR TITLE
WS1-D start: move map contracts behind maps registry

### DIFF
--- a/docs/05_roadmap/README.md
+++ b/docs/05_roadmap/README.md
@@ -44,7 +44,7 @@ Non-test code only; test-code coupling is tracked separately in WS6.
 |---|---|---|---|
 | V1 | Resolved: `utils.object_management` no longer hardcodes `waste_collection.Collection` knowledge | PR #179 moved review-context/search-field/update-context hooks behind source-owned registration | Keep domain-specific review context in source app hooks (WS1-A) |
 | V2 | Resolved: `utils.properties` and shared form helpers no longer import `bibliography` | PR #183 moved bibliography-backed `sources` fields to concrete domain models and made shared source-form helpers infer the source model from the form field | Keep attribution ownership in domain models (WS1-B) |
-| V3 | `utils.file_export` discovers `sources` plugins | `utils/file_export/registry_init.py` | Invert: source apps push exports into `export_registry` from their own `AppConfig.ready()` (WS1-C) |
+| V3 | Resolved: `utils.file_export` no longer discovers `sources` plugins | PR #190 moved export registration into source app `AppConfig.ready()` methods | Keep source export specs source-owned (WS1-C) |
 | V4 | `maps` imports `sources.registry` | `maps/urls.py:3`, `maps/tasks.py:11`, `maps/runtime_adapters.py:12`, `maps/management/commands/warm_geojson_cache.py` | Move the *contract* (map mounts, cache warmers, runtime compatibility) into `maps`; source apps register themselves (WS1-D) |
 | V5 | `maps` hardcodes domain dataset names | `maps/models.py:33-39` (`GIS_SOURCE_MODELS` incl. `WasteCollection`), legacy `GeoDataset.model_name` | Finish runtime-configuration migration, delete legacy name dispatch (WS1-D, overlaps #85) |
 | V6 | `layer_manager` imports `inventories`, `materials`, `distributions` | `layer_manager/models.py:6-8` | Merge `layer_manager` into `inventories` (it is its private result store) or genericize via contenttypes (WS8) |
@@ -79,6 +79,7 @@ The single most important arc. Sub-items in implementation order:
    each source app calls `register_export(...)` in its own `ready()`. The
    `sources.contracts.SourceDomainExport` dataclass moves to
    `utils.file_export.contracts` (it is a core contract, not a domain one).
+   **Status:** completed in PR #190.
 4. **D. Maps/sources inversion (V4, V5).** Move the mount/warmer/runtime-compat
    contracts from `sources/registry.py` into `maps.contracts` (or a new tiny
    `core_registry`), keep discovery in `sources` but have `maps` consume only its own
@@ -347,4 +348,4 @@ decoupling), #87 (soilcom cleanup), #139/#141/#145 (GeoJSON/serialization
 performance & cache warmup), #142 (collector NOT NULL), #143 (normalization bug),
 #106 (legacy unit field).
 
-_Last updated: 2026-06-09_
+_Last updated: 2026-06-23_

--- a/maps/contracts.py
+++ b/maps/contracts.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+
+from django.utils.module_loading import import_string
+
+
+@dataclass(frozen=True)
+class SourceDomainMapMount:
+    mount_path: str
+    urlconf: str
+
+
+@dataclass(frozen=True)
+class SourceDomainDatasetRuntimeCompatibility:
+    runtime_model_name: str
+    model: str
+    filterset_class: str
+    template_name: str
+    features_api_basename: str
+    apply_user_visibility_filter: bool = True
+
+    def resolve_model(self):
+        return import_string(self.model)
+
+    def resolve_filterset_class(self):
+        return import_string(self.filterset_class)

--- a/maps/management/commands/warm_geojson_cache.py
+++ b/maps/management/commands/warm_geojson_cache.py
@@ -27,12 +27,12 @@ from django.core.cache import caches
 from django.core.management.base import BaseCommand
 
 from maps.models import NutsRegion, Region
+from maps.registry import get_source_domain_geojson_cache_warmers
 from maps.serializers import (
     NutsRegionGeometrySerializer,
     RegionGeoFeatureModelSerializer,
 )
 from maps.utils import get_region_cache_key
-from sources.registry import get_source_domain_geojson_cache_warmers
 
 # Number of largest regions to warm by default. The H27 "Client Request
 # Interrupted" warnings come almost entirely from crawlers fetching the few

--- a/maps/registry.py
+++ b/maps/registry.py
@@ -1,0 +1,75 @@
+from maps.contracts import (
+    SourceDomainDatasetRuntimeCompatibility,
+    SourceDomainMapMount,
+)
+
+DatasetRuntimeCompatibilities = tuple[SourceDomainDatasetRuntimeCompatibility, ...]
+
+_MAP_MOUNTS: list[SourceDomainMapMount] = []
+_GEOJSON_CACHE_WARMERS: dict[str, object] = {}
+_DATASET_RUNTIME_COMPATIBILITIES: dict[
+    str, SourceDomainDatasetRuntimeCompatibility
+] = {}
+
+
+def _register_unique(registry, key, value, *, label):
+    existing = registry.get(key)
+    if existing is not None and existing != value:
+        raise ValueError(f"Duplicate {label} registration for {key}.")
+    registry[key] = value
+
+
+def register_source_domain_map_contracts(
+    *,
+    slug: str,
+    map_mount: SourceDomainMapMount | None = None,
+    geojson_cache_warmer=None,
+    dataset_runtime_compatibilities: DatasetRuntimeCompatibilities = (),
+) -> None:
+    if map_mount is not None:
+        if map_mount not in _MAP_MOUNTS:
+            _MAP_MOUNTS.append(map_mount)
+    if geojson_cache_warmer is not None:
+        _register_unique(
+            _GEOJSON_CACHE_WARMERS,
+            slug,
+            geojson_cache_warmer,
+            label="GeoJSON cache warmer",
+        )
+    for compatibility in dataset_runtime_compatibilities:
+        _register_unique(
+            _DATASET_RUNTIME_COMPATIBILITIES,
+            compatibility.runtime_model_name,
+            compatibility,
+            label="dataset runtime compatibility",
+        )
+
+
+def get_source_domain_map_mounts() -> tuple[SourceDomainMapMount, ...]:
+    return tuple(
+        sorted(
+            _MAP_MOUNTS,
+            key=lambda map_mount: (map_mount.mount_path, map_mount.urlconf),
+        )
+    )
+
+
+def get_source_domain_geojson_cache_warmers() -> tuple[tuple[str, object], ...]:
+    return tuple(sorted(_GEOJSON_CACHE_WARMERS.items()))
+
+
+def get_source_domain_dataset_runtime_compatibilities() -> (
+    DatasetRuntimeCompatibilities
+):
+    return tuple(
+        sorted(
+            _DATASET_RUNTIME_COMPATIBILITIES.values(),
+            key=lambda compatibility: compatibility.runtime_model_name,
+        )
+    )
+
+
+def get_source_domain_dataset_runtime_compatibility(
+    runtime_model_name: str,
+) -> SourceDomainDatasetRuntimeCompatibility | None:
+    return _DATASET_RUNTIME_COMPATIBILITIES.get(runtime_model_name)

--- a/maps/registry.py
+++ b/maps/registry.py
@@ -1,11 +1,15 @@
+from collections.abc import Callable
+
 from maps.contracts import (
     SourceDomainDatasetRuntimeCompatibility,
     SourceDomainMapMount,
 )
 
 DatasetRuntimeCompatibilities = tuple[SourceDomainDatasetRuntimeCompatibility, ...]
+SourceDomainMapMountListener = Callable[[SourceDomainMapMount], None]
 
 _MAP_MOUNTS: list[SourceDomainMapMount] = []
+_MAP_MOUNT_LISTENERS: list[SourceDomainMapMountListener] = []
 _GEOJSON_CACHE_WARMERS: dict[str, object] = {}
 _DATASET_RUNTIME_COMPATIBILITIES: dict[
     str, SourceDomainDatasetRuntimeCompatibility
@@ -26,9 +30,11 @@ def register_source_domain_map_contracts(
     geojson_cache_warmer=None,
     dataset_runtime_compatibilities: DatasetRuntimeCompatibilities = (),
 ) -> None:
+    new_map_mount = None
     if map_mount is not None:
         if map_mount not in _MAP_MOUNTS:
             _MAP_MOUNTS.append(map_mount)
+            new_map_mount = map_mount
     if geojson_cache_warmer is not None:
         _register_unique(
             _GEOJSON_CACHE_WARMERS,
@@ -43,6 +49,18 @@ def register_source_domain_map_contracts(
             compatibility,
             label="dataset runtime compatibility",
         )
+    if new_map_mount is not None:
+        for listener in _MAP_MOUNT_LISTENERS:
+            listener(new_map_mount)
+
+
+def register_source_domain_map_mount_listener(
+    listener: SourceDomainMapMountListener,
+) -> None:
+    if listener not in _MAP_MOUNT_LISTENERS:
+        _MAP_MOUNT_LISTENERS.append(listener)
+    for map_mount in get_source_domain_map_mounts():
+        listener(map_mount)
 
 
 def get_source_domain_map_mounts() -> tuple[SourceDomainMapMount, ...]:

--- a/maps/runtime_adapters.py
+++ b/maps/runtime_adapters.py
@@ -9,7 +9,7 @@ from django.http import Http404
 
 from maps.filters import NutsRegionFilterSet
 from maps.models import NutsRegion
-from sources.registry import get_source_domain_dataset_runtime_compatibility
+from maps.registry import get_source_domain_dataset_runtime_compatibility
 
 LEGACY_DATASET_RUNTIME_COMPATIBILITY = {
     "NutsRegion": {

--- a/maps/tasks.py
+++ b/maps/tasks.py
@@ -8,7 +8,7 @@ import logging
 
 from celery import shared_task
 
-from sources.registry import get_source_domain_geojson_cache_warmers
+from maps.registry import get_source_domain_geojson_cache_warmers
 
 logger = logging.getLogger(__name__)
 

--- a/maps/tests/test_layering.py
+++ b/maps/tests/test_layering.py
@@ -1,0 +1,29 @@
+import ast
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+
+class MapsLayeringTests(SimpleTestCase):
+    def test_maps_does_not_import_source_registry(self):
+        maps_dir = Path(__file__).resolve().parent.parent
+        offenders = []
+
+        for path in maps_dir.rglob("*.py"):
+            relative_path = path.relative_to(maps_dir)
+            if relative_path.parts[0] in {"migrations", "tests"}:
+                continue
+            tree = ast.parse(path.read_text(), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ImportFrom) and node.module == "sources.registry":
+                    offenders.append(str(relative_path))
+                elif isinstance(node, ast.Import):
+                    for alias in node.names:
+                        if alias.name == "sources.registry":
+                            offenders.append(str(relative_path))
+
+        self.assertEqual(
+            offenders,
+            [],
+            "maps modules must consume maps-owned registries, not sources.registry",
+        )

--- a/maps/tests/test_registry.py
+++ b/maps/tests/test_registry.py
@@ -1,0 +1,64 @@
+from django.test import SimpleTestCase
+
+from maps import registry, urls
+from maps.contracts import SourceDomainMapMount
+
+urlpatterns = []
+
+
+class SourceDomainMapRegistryTests(SimpleTestCase):
+    def setUp(self):
+        self.original_map_mounts = list(registry._MAP_MOUNTS)
+        self.original_listeners = list(registry._MAP_MOUNT_LISTENERS)
+        self.original_urlpatterns = list(urls.urlpatterns)
+        self.original_urlpattern_keys = list(urls._SOURCE_DOMAIN_MAP_MOUNT_PATTERN_KEYS)
+        registry._MAP_MOUNTS.clear()
+        registry._MAP_MOUNT_LISTENERS.clear()
+        urls.urlpatterns[:] = urls.urlpatterns[
+            : urls._SOURCE_DOMAIN_MAP_MOUNT_INSERT_INDEX
+        ] + urls.urlpatterns[
+            urls._SOURCE_DOMAIN_MAP_MOUNT_INSERT_INDEX
+            + len(urls._SOURCE_DOMAIN_MAP_MOUNT_PATTERN_KEYS) :
+        ]
+        urls._SOURCE_DOMAIN_MAP_MOUNT_PATTERN_KEYS.clear()
+
+    def tearDown(self):
+        registry._MAP_MOUNTS[:] = self.original_map_mounts
+        registry._MAP_MOUNT_LISTENERS[:] = self.original_listeners
+        urls.urlpatterns[:] = self.original_urlpatterns
+        urls._SOURCE_DOMAIN_MAP_MOUNT_PATTERN_KEYS[:] = self.original_urlpattern_keys
+
+    def test_map_mount_listener_receives_mount_registered_after_url_module_loaded(self):
+        registry.register_source_domain_map_mount_listener(
+            urls._append_source_domain_map_mount_pattern
+        )
+
+        registry.register_source_domain_map_contracts(
+            slug="late-test",
+            map_mount=SourceDomainMapMount(
+                mount_path="late-test/",
+                urlconf=__name__,
+            ),
+        )
+
+        matching_patterns = [
+            url_pattern
+            for url_pattern in urls.urlpatterns
+            if getattr(url_pattern.pattern, "_route", "") == "late-test/"
+        ]
+        self.assertEqual(len(matching_patterns), 1)
+
+    def test_map_mount_listener_replays_previously_registered_mounts(self):
+        map_mount = SourceDomainMapMount(
+            mount_path="existing-test/",
+            urlconf=__name__,
+        )
+        registry.register_source_domain_map_contracts(
+            slug="existing-test",
+            map_mount=map_mount,
+        )
+
+        observed = []
+        registry.register_source_domain_map_mount_listener(observed.append)
+
+        self.assertEqual(observed, [map_mount])

--- a/maps/urls.py
+++ b/maps/urls.py
@@ -1,6 +1,6 @@
 from django.urls import include, path
 
-from sources.registry import get_source_domain_map_mounts
+from maps.registry import get_source_domain_map_mounts
 
 from .router import router
 from .views import (

--- a/maps/urls.py
+++ b/maps/urls.py
@@ -1,6 +1,7 @@
 from django.urls import include, path
 
-from maps.registry import get_source_domain_map_mounts
+from maps.contracts import SourceDomainMapMount
+from maps.registry import register_source_domain_map_mount_listener
 
 from .router import router
 from .views import (
@@ -326,10 +327,27 @@ urlpatterns = [
         NutsAndLauCatchmentPedigreeAPI.as_view(),
         name="data.nuts_lau_catchment_options",
     ),
-    *[
-        path(map_mount.mount_path, include(map_mount.urlconf))
-        for map_mount in get_source_domain_map_mounts()
-    ],
+]
+
+_SOURCE_DOMAIN_MAP_MOUNT_INSERT_INDEX = len(urlpatterns)
+_SOURCE_DOMAIN_MAP_MOUNT_PATTERN_KEYS: list[tuple[str, str]] = []
+
+
+def _append_source_domain_map_mount_pattern(map_mount: SourceDomainMapMount) -> None:
+    pattern_key = (map_mount.mount_path, map_mount.urlconf)
+    if pattern_key in _SOURCE_DOMAIN_MAP_MOUNT_PATTERN_KEYS:
+        return
+    insert_index = (
+        _SOURCE_DOMAIN_MAP_MOUNT_INSERT_INDEX
+        + len(_SOURCE_DOMAIN_MAP_MOUNT_PATTERN_KEYS)
+    )
+    _SOURCE_DOMAIN_MAP_MOUNT_PATTERN_KEYS.append(pattern_key)
+    urlpatterns.insert(insert_index, path(map_mount.mount_path, include(map_mount.urlconf)))
+
+
+register_source_domain_map_mount_listener(_append_source_domain_map_mount_pattern)
+
+urlpatterns += [
     path("locations/", LocationPublishedListView.as_view(), name="location-list"),
     path(
         "locations/user/", LocationPrivateListView.as_view(), name="location-list-owned"

--- a/sources/apps.py
+++ b/sources/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class SourcesConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "sources"
+
+    def ready(self):
+        from sources import registry  # noqa: F401

--- a/sources/contracts.py
+++ b/sources/contracts.py
@@ -1,7 +1,10 @@
 from dataclasses import dataclass
 from importlib import import_module
 
-from django.utils.module_loading import import_string
+from maps.contracts import (
+    SourceDomainDatasetRuntimeCompatibility,
+    SourceDomainMapMount,
+)
 
 
 @dataclass(frozen=True)
@@ -23,31 +26,9 @@ class SourceDomainLegacyRedirects:
 
 
 @dataclass(frozen=True)
-class SourceDomainMapMount:
-    mount_path: str
-    urlconf: str
-
-
-@dataclass(frozen=True)
 class SourceDomainPublicMount:
     mount_path: str
     urlconf: str
-
-
-@dataclass(frozen=True)
-class SourceDomainDatasetRuntimeCompatibility:
-    runtime_model_name: str
-    model: str
-    filterset_class: str
-    template_name: str
-    features_api_basename: str
-    apply_user_visibility_filter: bool = True
-
-    def resolve_model(self):
-        return import_string(self.model)
-
-    def resolve_filterset_class(self):
-        return import_string(self.filterset_class)
 
 
 @dataclass(frozen=True)

--- a/sources/registry.py
+++ b/sources/registry.py
@@ -3,6 +3,7 @@ from importlib import import_module
 from django.apps import apps
 from django.core.cache import cache
 
+from maps.registry import register_source_domain_map_contracts
 from sources.contracts import (
     SourceDomainDatasetRuntimeCompatibility,
     SourceDomainExplorerCard,
@@ -235,6 +236,14 @@ def _discover_source_domain_plugins() -> tuple[SourceDomainPlugin, ...]:
 _SOURCE_DOMAIN_PLUGINS: tuple[SourceDomainPlugin, ...] = (
     _discover_source_domain_plugins()
 )
+
+for plugin in _SOURCE_DOMAIN_PLUGINS:
+    register_source_domain_map_contracts(
+        slug=plugin.slug,
+        map_mount=plugin.map_mount,
+        geojson_cache_warmer=plugin.get_geojson_cache_warmer(),
+        dataset_runtime_compatibilities=plugin.dataset_runtime_compatibilities,
+    )
 
 
 def get_source_domain_plugins() -> tuple[SourceDomainPlugin, ...]:


### PR DESCRIPTION
## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Summary

Starts WS1-D by making `maps` consume map-owned contracts instead of importing `sources.registry`:

```text
sources plugin metadata
  -> sources.registry discovery
  -> maps.registry.register_source_domain_map_contracts(...)
  -> maps.registry map-mount listeners / runtime lookups / warmer lookups
  -> maps.urls / maps.tasks / maps.runtime_adapters
```

`SourceDomainMapMount` and `SourceDomainDatasetRuntimeCompatibility` now live in `maps.contracts` and remain re-exported from `sources.contracts` to avoid broad source-plugin churn in this slice. `SourcesConfig.ready()` imports `sources.registry` so Celery/Django startup populates the maps registry before map tasks need warmers or runtime compatibility data.

Follow-up for Devin Review: `maps.urls` now subscribes to maps-owned map-mount registration callbacks. If `maps.urls` is evaluated before `SourcesConfig.ready()` imports `sources.registry`, late source map registrations are inserted into `urlpatterns` instead of leaving source-mounted routes silently absent.

The roadmap is also updated to mark WS1-C / PR #190 complete.

## Verification

- [x] Focused tests or checks were run.
  - `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT --print-targets` → printed `maps.tests.test_layering`
  - `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- maps.tests.test_layering` → failed before the implementation with `runtime_adapters.py`, `urls.py`, `tasks.py`, and `management/commands/warm_geojson_cache.py` importing `sources.registry`; passed after the implementation
  - `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- maps.tests.test_layering maps.tests.test_tasks maps.tests.test_commands maps.tests.test_geodataset_runtime_routes sources.tests.test_models sources.tests.test_views` → 120 passed
  - `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- maps.tests.test_models maps.tests.test_views` → 454 passed, 104 skipped
  - `/home/ubuntu/BRIT-ops/scripts/brit-worktree-compose /home/ubuntu/repos/BRIT exec -T web ruff check maps/contracts.py maps/registry.py maps/urls.py maps/tasks.py maps/runtime_adapters.py maps/management/commands/warm_geojson_cache.py maps/tests/test_layering.py sources/apps.py sources/contracts.py sources/registry.py` → passed
  - `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- maps.tests.test_registry maps.tests.test_layering` → 3 passed
  - `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- sources.roadside_trees.tests.test_views maps.tests.test_registry maps.tests.test_layering` → 14 passed
  - `/home/ubuntu/BRIT-ops/scripts/brit-worktree-compose /home/ubuntu/repos/BRIT exec -T web ruff check maps/registry.py maps/urls.py maps/tests/test_registry.py` → passed
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed. No source JS/CSS/SCSS changed.
- [x] No secrets, raw data, or production-only configuration are included.

Link to Devin session: https://app.devin.ai/sessions/a9e96bccc03b4989b10c04d356986665
Requested by: @lueho