### PR TITLE
WS1-E: initialize source registry in ready lifecycle

### DIFF
--- a/docs/05_roadmap/README.md
+++ b/docs/05_roadmap/README.md
@@ -45,7 +45,7 @@ Non-test code only; test-code coupling is tracked separately in WS6.
 | V1 | Resolved: `utils.object_management` no longer hardcodes `waste_collection.Collection` knowledge | PR #179 moved review-context/search-field/update-context hooks behind source-owned registration | Keep domain-specific review context in source app hooks (WS1-A) |
 | V2 | Resolved: `utils.properties` and shared form helpers no longer import `bibliography` | PR #183 moved bibliography-backed `sources` fields to concrete domain models and made shared source-form helpers infer the source model from the form field | Keep attribution ownership in domain models (WS1-B) |
 | V3 | Resolved: `utils.file_export` no longer discovers `sources` plugins | PR #190 moved export registration into source app `AppConfig.ready()` methods | Keep source export specs source-owned (WS1-C) |
-| V4 | `maps` imports `sources.registry` | `maps/urls.py:3`, `maps/tasks.py:11`, `maps/runtime_adapters.py:12`, `maps/management/commands/warm_geojson_cache.py` | Move the *contract* (map mounts, cache warmers, runtime compatibility) into `maps`; source apps register themselves (WS1-D) |
+| V4 | Resolved: `maps` no longer imports `sources.registry` | PR #194 moved map mounts, cache warmers, and runtime compatibility behind `maps.contracts` / `maps.registry` with source-owned registration | Keep map integration through maps-owned contracts (WS1-D start) |
 | V5 | `maps` hardcodes domain dataset names | `maps/models.py:33-39` (`GIS_SOURCE_MODELS` incl. `WasteCollection`), legacy `GeoDataset.model_name` | Finish runtime-configuration migration, delete legacy name dispatch (WS1-D, overlaps #85) |
 | V6 | `layer_manager` imports `inventories`, `materials`, `distributions` | `layer_manager/models.py:6-8` | Merge `layer_manager` into `inventories` (it is its private result store) or genericize via contenttypes (WS8) |
 | V7 | `inventories` discovers algorithms via `pkgutil` over `sources` + DB dotted paths | `inventories/models.py:31-36,88-106,158-163` | Replace with the source-domain plugin registry; drop `flexibi_hamburg` aliases (WS8) |
@@ -88,9 +88,11 @@ The single most important arc. Sub-items in implementation order:
    string-dispatch (migration + data backfill to `GeoDatasetRuntimeConfiguration`).
    Existing issue #86 ("Sources plugin decoupling: finish remaining phases") is the
    umbrella; #85 (geodataset harmonization) is the data side.
+   **Status:** V4 contract move completed in PR #194; V5 legacy runtime cleanup remains.
 5. **E. Registry robustness.** `sources/registry.py:235` runs discovery at import time.
    Move initialization to `AppConfig.ready()` with an explicit, validated lifecycle so
    a broken plugin yields a clear startup error, not an import-order heisenbug.
+   **Status:** in progress in the next focused PR after #194.
 6. **F. Enforcement.** Add import-linter (or a dedicated test) encoding the table in
    §1, run in CI. From then on the layering is a build invariant, not a convention.
 
@@ -300,8 +302,8 @@ consolidation that pays compounding dividends.
 **Phase 1 — Foundation inversion (next, ~1 month)**
 5. Object-management hooks; strip waste_collection out of utils (WS1-A)
 6. Properties/bibliography attribution inversion (WS1-B)
-7. Export-registry inversion (WS1-C) and maps/sources contract move (WS1-D start)
-8. Registry init in `ready()` (WS1-E); layering check in CI (WS1-F)
+7. Export-registry inversion (WS1-C) and maps/sources contract move (WS1-D start) — completed through PR #194
+8. Registry init in `ready()` (WS1-E); layering check in CI (WS1-F) — in progress
 9. Decide inventories future (WS8)
 
 **Phase 2 — Consolidation (months 2–3)**

--- a/sources/apps.py
+++ b/sources/apps.py
@@ -6,4 +6,6 @@ class SourcesConfig(AppConfig):
     name = "sources"
 
     def ready(self):
-        from sources import registry  # noqa: F401
+        from sources.registry import initialize_source_domain_registry
+
+        initialize_source_domain_registry()

--- a/sources/registry.py
+++ b/sources/registry.py
@@ -2,6 +2,7 @@ from importlib import import_module
 
 from django.apps import apps
 from django.core.cache import cache
+from django.core.exceptions import ImproperlyConfigured
 
 from maps.registry import register_source_domain_map_contracts
 from sources.contracts import (
@@ -233,25 +234,45 @@ def _discover_source_domain_plugins() -> tuple[SourceDomainPlugin, ...]:
     return discovered_plugins
 
 
-_SOURCE_DOMAIN_PLUGINS: tuple[SourceDomainPlugin, ...] = (
-    _discover_source_domain_plugins()
-)
-
-for plugin in _SOURCE_DOMAIN_PLUGINS:
-    register_source_domain_map_contracts(
-        slug=plugin.slug,
-        map_mount=plugin.map_mount,
-        geojson_cache_warmer=plugin.get_geojson_cache_warmer(),
-        dataset_runtime_compatibilities=plugin.dataset_runtime_compatibilities,
-    )
+_SOURCE_DOMAIN_PLUGINS: tuple[SourceDomainPlugin, ...] = ()
+_SOURCE_DOMAIN_REGISTRY_INITIALIZED = False
 
 
-def get_source_domain_plugins() -> tuple[SourceDomainPlugin, ...]:
+def initialize_source_domain_registry() -> None:
+    global _SOURCE_DOMAIN_PLUGINS, _SOURCE_DOMAIN_REGISTRY_INITIALIZED
+
+    if _SOURCE_DOMAIN_REGISTRY_INITIALIZED:
+        return
+
+    plugins = _discover_source_domain_plugins()
+    for plugin in plugins:
+        register_source_domain_map_contracts(
+            slug=plugin.slug,
+            map_mount=plugin.map_mount,
+            geojson_cache_warmer=plugin.get_geojson_cache_warmer(),
+            dataset_runtime_compatibilities=plugin.dataset_runtime_compatibilities,
+        )
+
+    _SOURCE_DOMAIN_PLUGINS = plugins
+    _SOURCE_DOMAIN_REGISTRY_INITIALIZED = True
+
+
+def _get_initialized_source_domain_plugins() -> tuple[SourceDomainPlugin, ...]:
+    if not _SOURCE_DOMAIN_REGISTRY_INITIALIZED:
+        raise ImproperlyConfigured(
+            "Source domain registry has not been initialized. "
+            "Call sources.registry.initialize_source_domain_registry() from "
+            "SourcesConfig.ready() before accessing source-domain plugins."
+        )
     return _SOURCE_DOMAIN_PLUGINS
 
 
+def get_source_domain_plugins() -> tuple[SourceDomainPlugin, ...]:
+    return _get_initialized_source_domain_plugins()
+
+
 def get_source_domain_plugin(slug: str) -> SourceDomainPlugin:
-    for plugin in _SOURCE_DOMAIN_PLUGINS:
+    for plugin in _get_initialized_source_domain_plugins():
         if plugin.slug == slug:
             return plugin
 
@@ -259,13 +280,17 @@ def get_source_domain_plugin(slug: str) -> SourceDomainPlugin:
 
 
 def get_hub_source_domain_plugins() -> tuple[SourceDomainPlugin, ...]:
-    return tuple(plugin for plugin in _SOURCE_DOMAIN_PLUGINS if plugin.mount_in_hub)
+    return tuple(
+        plugin
+        for plugin in _get_initialized_source_domain_plugins()
+        if plugin.mount_in_hub
+    )
 
 
 def get_source_domain_explorer_cards() -> tuple[dict[str, object], ...]:
     cards: list[dict[str, object]] = []
 
-    for plugin in _SOURCE_DOMAIN_PLUGINS:
+    for plugin in _get_initialized_source_domain_plugins():
         if plugin.explorer_card is None:
             continue
 
@@ -296,7 +321,7 @@ def get_source_domain_explorer_cards() -> tuple[dict[str, object], ...]:
 def get_source_domain_legacy_redirects() -> tuple[SourceDomainLegacyRedirects, ...]:
     redirects: list[SourceDomainLegacyRedirects] = []
 
-    for plugin in _SOURCE_DOMAIN_PLUGINS:
+    for plugin in _get_initialized_source_domain_plugins():
         if plugin.legacy_redirects is None:
             continue
         redirects.append(plugin.legacy_redirects)
@@ -307,7 +332,7 @@ def get_source_domain_legacy_redirects() -> tuple[SourceDomainLegacyRedirects, .
 def get_source_domain_map_mounts() -> tuple[SourceDomainMapMount, ...]:
     map_mounts: list[SourceDomainMapMount] = []
 
-    for plugin in _SOURCE_DOMAIN_PLUGINS:
+    for plugin in _get_initialized_source_domain_plugins():
         if plugin.map_mount is None:
             continue
         map_mounts.append(plugin.map_mount)
@@ -322,7 +347,7 @@ def get_source_domain_map_mounts() -> tuple[SourceDomainMapMount, ...]:
 def get_source_domain_public_mounts() -> tuple[SourceDomainPublicMount, ...]:
     public_mounts: list[SourceDomainPublicMount] = []
 
-    for plugin in _SOURCE_DOMAIN_PLUGINS:
+    for plugin in _get_initialized_source_domain_plugins():
         if plugin.public_mount is None:
             continue
         public_mounts.append(plugin.public_mount)
@@ -336,7 +361,7 @@ def get_source_domain_sitemap_items() -> tuple[str, ...]:
     sitemap_items: list[str] = []
     seen_items: set[str] = set()
 
-    for plugin in _SOURCE_DOMAIN_PLUGINS:
+    for plugin in _get_initialized_source_domain_plugins():
         for item in plugin.sitemap_items:
             if item in seen_items:
                 continue
@@ -349,7 +374,7 @@ def get_source_domain_sitemap_items() -> tuple[str, ...]:
 def get_source_domain_geojson_cache_warmers() -> tuple[tuple[str, object], ...]:
     warmers: list[tuple[str, object]] = []
 
-    for plugin in _SOURCE_DOMAIN_PLUGINS:
+    for plugin in _get_initialized_source_domain_plugins():
         warmer = plugin.get_geojson_cache_warmer()
         if warmer is None:
             continue
@@ -363,7 +388,7 @@ def get_source_domain_dataset_runtime_compatibilities() -> (
 ):
     compatibilities: list[SourceDomainDatasetRuntimeCompatibility] = []
 
-    for plugin in _SOURCE_DOMAIN_PLUGINS:
+    for plugin in _get_initialized_source_domain_plugins():
         compatibilities.extend(plugin.dataset_runtime_compatibilities)
 
     return tuple(

--- a/sources/tests/test_models.py
+++ b/sources/tests/test_models.py
@@ -3,8 +3,11 @@ from dataclasses import replace
 from unittest.mock import MagicMock, patch
 
 from django.apps import apps
+from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase
 
+from sources import registry as source_domain_registry
+from sources.apps import SourcesConfig
 from sources.contracts import (
     SourceDomainDatasetRuntimeCompatibility,
 )
@@ -36,6 +39,93 @@ from utils.file_export.contracts import SourceDomainExport
 
 
 class SourceDomainPluginContractTestCase(SimpleTestCase):
+    def test_sources_config_ready_initializes_registry(self):
+        sources_module = importlib.import_module("sources")
+        config = SourcesConfig("sources", sources_module)
+
+        with patch(
+            "sources.registry.initialize_source_domain_registry"
+        ) as mock_initialize:
+            config.ready()
+
+        mock_initialize.assert_called_once_with()
+
+    def test_getters_require_ready_lifecycle_instead_of_import_time_discovery(self):
+        with (
+            patch("sources.registry._SOURCE_DOMAIN_PLUGINS", ()),
+            patch(
+                "sources.registry._SOURCE_DOMAIN_REGISTRY_INITIALIZED",
+                False,
+                create=True,
+            ),
+            patch(
+                "sources.registry._discover_source_domain_plugins"
+            ) as mock_discover_source_domain_plugins,
+        ):
+            with self.assertRaisesMessage(
+                ImproperlyConfigured,
+                "Source domain registry has not been initialized",
+            ):
+                get_source_domain_plugins()
+
+        mock_discover_source_domain_plugins.assert_not_called()
+
+    def test_initialize_source_domain_registry_discovers_and_registers_maps_contracts(
+        self,
+    ):
+        plugin = get_source_domain_plugin("roadside_trees")
+
+        with (
+            patch("sources.registry._SOURCE_DOMAIN_PLUGINS", ()),
+            patch(
+                "sources.registry._SOURCE_DOMAIN_REGISTRY_INITIALIZED",
+                False,
+                create=True,
+            ),
+            patch(
+                "sources.registry._discover_source_domain_plugins",
+                return_value=(plugin,),
+            ) as mock_discover_source_domain_plugins,
+            patch(
+                "sources.registry.register_source_domain_map_contracts"
+            ) as mock_register_map_contracts,
+        ):
+            source_domain_registry.initialize_source_domain_registry()
+
+            self.assertEqual(get_source_domain_plugins(), (plugin,))
+
+        mock_discover_source_domain_plugins.assert_called_once_with()
+        mock_register_map_contracts.assert_called_once_with(
+            slug=plugin.slug,
+            map_mount=plugin.map_mount,
+            geojson_cache_warmer=plugin.get_geojson_cache_warmer(),
+            dataset_runtime_compatibilities=plugin.dataset_runtime_compatibilities,
+        )
+
+    def test_initialize_source_domain_registry_is_idempotent(self):
+        plugin = get_source_domain_plugin("roadside_trees")
+
+        with (
+            patch("sources.registry._SOURCE_DOMAIN_PLUGINS", ()),
+            patch(
+                "sources.registry._SOURCE_DOMAIN_REGISTRY_INITIALIZED",
+                False,
+                create=True,
+            ),
+            patch(
+                "sources.registry._discover_source_domain_plugins",
+                return_value=(plugin,),
+            ) as mock_discover_source_domain_plugins,
+            patch(
+                "sources.registry.register_source_domain_map_contracts"
+            ) as mock_register_map_contracts,
+        ):
+            source_domain_registry.initialize_source_domain_registry()
+            source_domain_registry.initialize_source_domain_registry()
+
+        mock_discover_source_domain_plugins.assert_called_once_with()
+        mock_register_map_contracts.assert_called_once()
+
     def test_registered_source_domain_plugins_expose_stable_slugs(self):
         self.assertEqual(
             tuple(plugin.slug for plugin in get_source_domain_plugins()),


### PR DESCRIPTION
## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

This PR advances WS1-E by moving source-domain plugin discovery out of `sources.registry` module import and into an explicit startup lifecycle:

```python
SourcesConfig.ready()
  -> initialize_source_domain_registry()
       -> discover + validate plugins
       -> register maps contracts
       -> mark initialized
```

Notable behavior:
- Source registry getters now fail fast with `ImproperlyConfigured` if accessed before app startup initializes the registry.
- `initialize_source_domain_registry()` is idempotent, so repeated `ready()` calls do not rediscover plugins or re-register maps contracts.
- The roadmap marks PR #194 as the completed WS1-D/V4 contract move and records WS1-E as the current focused slice.

## Verification

- [x] Focused tests or checks were run.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed.
- [x] No secrets, raw data, or production-only configuration are included.

Static assets were not changed.

Checks run:
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT --print-targets` → `sources.tests.test_models`
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- sources.tests.test_models.SourceDomainPluginContractTestCase` → 12 passed
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- sources.tests.test_models sources.tests.test_views maps.tests.test_registry maps.tests.test_layering` → 86 passed
- `/home/ubuntu/BRIT-ops/scripts/brit-worktree-compose /home/ubuntu/repos/BRIT exec -T web ruff check sources/apps.py sources/registry.py sources/tests/test_models.py` → passed

Link to Devin session: https://app.devin.ai/sessions/a9e96bccc03b4989b10c04d356986665
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->