### PR TITLE
fix(inventories): add auth to scenario endpoints and fix authz bypass

### DIFF
--- a/inventories/tests/test_views.py
+++ b/inventories/tests/test_views.py
@@ -301,6 +301,22 @@ class ScenarioDownloadSummaryAuthTests(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
+    def test_moderator_can_download(self):
+        moderator = User.objects.create_user(username="mod", password="pass")
+        ct = ContentType.objects.get_for_model(Scenario)
+        perm, _ = Permission.objects.get_or_create(
+            codename="can_moderate_scenario",
+            content_type=ct,
+            defaults={"name": "Can moderate scenario"},
+        )
+        moderator.user_permissions.add(perm)
+        self.client.force_login(moderator)
+        url = reverse(
+            "scenario-download-summary", kwargs={"scenario_pk": self.scenario.pk}
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
 
 class ScenarioDownloadResultSummaryAuthTests(TestCase):
     @classmethod
@@ -337,6 +353,23 @@ class ScenarioDownloadResultSummaryAuthTests(TestCase):
 
     def test_owner_can_download(self):
         self.client.force_login(self.owner)
+        url = reverse(
+            "scenario-download-result-summary",
+            kwargs={"scenario_pk": self.scenario.pk},
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_moderator_can_download(self):
+        moderator = User.objects.create_user(username="mod", password="pass")
+        ct = ContentType.objects.get_for_model(Scenario)
+        perm, _ = Permission.objects.get_or_create(
+            codename="can_moderate_scenario",
+            content_type=ct,
+            defaults={"name": "Can moderate scenario"},
+        )
+        moderator.user_permissions.add(perm)
+        self.client.force_login(moderator)
         url = reverse(
             "scenario-download-result-summary",
             kwargs={"scenario_pk": self.scenario.pk},

--- a/inventories/tests/test_views.py
+++ b/inventories/tests/test_views.py
@@ -269,26 +269,35 @@ class ScenarioDownloadSummaryAuthTests(TestCase):
         cls.other_user = User.objects.create_user(username="other", password="pass")
         region = Region.objects.create(name="R", publication_status="published")
         catchment = Catchment.objects.create(
-            name="C", region=region, parent_region=region, publication_status="published"
+            name="C",
+            region=region,
+            parent_region=region,
+            publication_status="published",
         )
         cls.scenario = Scenario.objects.create(
             name="S", owner=cls.owner, region=region, catchment=catchment
         )
 
     def test_anonymous_is_denied(self):
-        url = reverse("scenario-download-summary", kwargs={"scenario_pk": self.scenario.pk})
+        url = reverse(
+            "scenario-download-summary", kwargs={"scenario_pk": self.scenario.pk}
+        )
         response = self.client.get(url)
         self.assertNotEqual(response.status_code, 200)
 
     def test_non_owner_non_staff_is_denied(self):
         self.client.force_login(self.other_user)
-        url = reverse("scenario-download-summary", kwargs={"scenario_pk": self.scenario.pk})
+        url = reverse(
+            "scenario-download-summary", kwargs={"scenario_pk": self.scenario.pk}
+        )
         response = self.client.get(url)
         self.assertIn(response.status_code, [302, 403])
 
     def test_owner_can_download(self):
         self.client.force_login(self.owner)
-        url = reverse("scenario-download-summary", kwargs={"scenario_pk": self.scenario.pk})
+        url = reverse(
+            "scenario-download-summary", kwargs={"scenario_pk": self.scenario.pk}
+        )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
@@ -300,7 +309,10 @@ class ScenarioDownloadResultSummaryAuthTests(TestCase):
         cls.other_user = User.objects.create_user(username="other", password="pass")
         region = Region.objects.create(name="R", publication_status="published")
         catchment = Catchment.objects.create(
-            name="C", region=region, parent_region=region, publication_status="published"
+            name="C",
+            region=region,
+            parent_region=region,
+            publication_status="published",
         )
         cls.scenario = Scenario.objects.create(
             name="S", owner=cls.owner, region=region, catchment=catchment
@@ -366,7 +378,10 @@ class ScenarioAddAlgorithmAuthBypassTests(TestCase):
         cls.owner_b = User.objects.create_user(username="owner_b", password="pass")
         region = Region.objects.create(name="R", publication_status="published")
         catchment = Catchment.objects.create(
-            name="C", region=region, parent_region=region, publication_status="published"
+            name="C",
+            region=region,
+            parent_region=region,
+            publication_status="published",
         )
         cls.scenario_a = Scenario.objects.create(
             name="A", owner=cls.owner_a, region=region, catchment=catchment

--- a/inventories/tests/test_views.py
+++ b/inventories/tests/test_views.py
@@ -2,11 +2,14 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 from uuid import uuid4
 
-from django.contrib.auth.models import AnonymousUser
+from django.contrib.auth.models import AnonymousUser, Permission
+from django.contrib.contenttypes.models import ContentType
 from django.test import SimpleTestCase, TestCase
+from django.urls import reverse
 
 from maps.models import Catchment, GeoDataset, Region
 from materials.models import Material, SampleSeries
+from utils.object_management.models import User
 from utils.object_management.views import (
     UserCreatedObjectAutocompleteView,
     get_tomselect_filter_pairs,
@@ -253,3 +256,142 @@ class ScenarioResultCRUDViewsTestCase(
                 publication_status="published",
             ),
         }
+
+
+# ----------- Issue #204: Unauthenticated endpoint tests --------------------------------------------------------------
+# ----------------------------------------------------------------------------------------------------------------------
+
+
+class ScenarioDownloadSummaryAuthTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.owner = User.objects.create_user(username="owner", password="pass")
+        cls.other_user = User.objects.create_user(username="other", password="pass")
+        region = Region.objects.create(name="R", publication_status="published")
+        catchment = Catchment.objects.create(
+            name="C", region=region, parent_region=region, publication_status="published"
+        )
+        cls.scenario = Scenario.objects.create(
+            name="S", owner=cls.owner, region=region, catchment=catchment
+        )
+
+    def test_anonymous_is_denied(self):
+        url = reverse("scenario-download-summary", kwargs={"scenario_pk": self.scenario.pk})
+        response = self.client.get(url)
+        self.assertNotEqual(response.status_code, 200)
+
+    def test_non_owner_non_staff_is_denied(self):
+        self.client.force_login(self.other_user)
+        url = reverse("scenario-download-summary", kwargs={"scenario_pk": self.scenario.pk})
+        response = self.client.get(url)
+        self.assertIn(response.status_code, [302, 403])
+
+    def test_owner_can_download(self):
+        self.client.force_login(self.owner)
+        url = reverse("scenario-download-summary", kwargs={"scenario_pk": self.scenario.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+
+class ScenarioDownloadResultSummaryAuthTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.owner = User.objects.create_user(username="owner", password="pass")
+        cls.other_user = User.objects.create_user(username="other", password="pass")
+        region = Region.objects.create(name="R", publication_status="published")
+        catchment = Catchment.objects.create(
+            name="C", region=region, parent_region=region, publication_status="published"
+        )
+        cls.scenario = Scenario.objects.create(
+            name="S", owner=cls.owner, region=region, catchment=catchment
+        )
+
+    def test_anonymous_is_denied(self):
+        url = reverse(
+            "scenario-download-result-summary",
+            kwargs={"scenario_pk": self.scenario.pk},
+        )
+        response = self.client.get(url)
+        self.assertNotEqual(response.status_code, 200)
+
+    def test_non_owner_non_staff_is_denied(self):
+        self.client.force_login(self.other_user)
+        url = reverse(
+            "scenario-download-result-summary",
+            kwargs={"scenario_pk": self.scenario.pk},
+        )
+        response = self.client.get(url)
+        self.assertIn(response.status_code, [302, 403])
+
+    def test_owner_can_download(self):
+        self.client.force_login(self.owner)
+        url = reverse(
+            "scenario-download-result-summary",
+            kwargs={"scenario_pk": self.scenario.pk},
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+
+class EvaluationStatusAuthTests(TestCase):
+    @patch("inventories.views.AsyncResult")
+    def test_anonymous_is_denied(self, mock_async):
+        mock_async.return_value.status = "PENDING"
+        mock_async.return_value.result = None
+        mock_async.return_value.info = None
+        url = reverse("scenario-evaluation-status", kwargs={"task_id": "fake-task-id"})
+        response = self.client.get(url)
+        self.assertNotEqual(response.status_code, 200)
+
+    @patch("inventories.views.AsyncResult")
+    def test_authenticated_can_access(self, mock_async):
+        mock_async.return_value.status = "PENDING"
+        mock_async.return_value.result = None
+        mock_async.return_value.info = None
+        user = User.objects.create_user(username="u", password="pass")
+        self.client.force_login(user)
+        url = reverse("scenario-evaluation-status", kwargs={"task_id": "fake-task-id"})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+
+# ----------- Issue #205: Authorization bypass test --------------------------------------------------------------------
+# ----------------------------------------------------------------------------------------------------------------------
+
+
+class ScenarioAddAlgorithmAuthBypassTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.owner_a = User.objects.create_user(username="owner_a", password="pass")
+        cls.owner_b = User.objects.create_user(username="owner_b", password="pass")
+        region = Region.objects.create(name="R", publication_status="published")
+        catchment = Catchment.objects.create(
+            name="C", region=region, parent_region=region, publication_status="published"
+        )
+        cls.scenario_a = Scenario.objects.create(
+            name="A", owner=cls.owner_a, region=region, catchment=catchment
+        )
+        cls.scenario_b = Scenario.objects.create(
+            name="B", owner=cls.owner_b, region=region, catchment=catchment
+        )
+
+    def test_post_uses_url_pk_not_body_scenario(self):
+        """post() must use the URL pk, ignoring any 'scenario' field in POST body."""
+        from unittest.mock import patch
+
+        self.client.force_login(self.owner_a)
+        url = reverse(
+            "scenario-add-configuration",
+            kwargs={"pk": self.scenario_a.pk},
+        )
+        # Patch add_inventory_algorithm to capture which scenario it was called on
+        with patch.object(Scenario, "add_inventory_algorithm") as mock_add:
+            mock_add.return_value = None
+            # Supply scenario_b in POST body, but the view should use scenario_a
+            # from the URL pk. We need valid-looking POST data for feedstock/algo.
+            from materials.models import SampleSeries
+
+            with self.assertRaises(SampleSeries.DoesNotExist):
+                self.client.post(url, {"scenario": self.scenario_b.pk})
+            # add_inventory_algorithm should NOT have been called with scenario_b
+            mock_add.assert_not_called()

--- a/inventories/views.py
+++ b/inventories/views.py
@@ -2,8 +2,9 @@ import io
 import json
 
 from celery.result import AsyncResult
+from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-from django.http import HttpResponse, JsonResponse
+from django.http import Http404, HttpResponse, HttpResponseForbidden, JsonResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse_lazy
 from django.views.generic import CreateView, DetailView, TemplateView, View
@@ -170,6 +171,7 @@ class ScenarioAutocompleteView(UserCreatedObjectAutocompleteView):
     model = Scenario
 
 
+@login_required
 def get_evaluation_status(request, task_id=None):
     task_result = AsyncResult(task_id)
     result = {
@@ -197,10 +199,8 @@ class ScenarioAddInventoryAlgorithmView(
         policy = get_object_policy(self.request.user, scenario, request=self.request)
         return policy["can_edit"]
 
-    @staticmethod
-    def post(request, *args, **kwargs):
-        scenario_id = request.POST.get("scenario")
-        scenario = Scenario.objects.get(id=scenario_id)
+    def post(self, request, *args, **kwargs):
+        scenario = Scenario.objects.get(id=self.kwargs.get("pk"))
         feedstock = SampleSeries.objects.get(id=request.POST.get("feedstock"))
         algorithm_id = request.POST.get("inventory_algorithm")
         algorithm = InventoryAlgorithm.objects.get(id=algorithm_id)
@@ -215,7 +215,7 @@ class ScenarioAddInventoryAlgorithmView(
                     InventoryAlgorithmParameterValue.objects.get(id=value_id)
                 )
         scenario.add_inventory_algorithm(feedstock, algorithm, values)
-        return redirect("scenario-detail", pk=scenario_id)
+        return redirect("scenario-detail", pk=scenario.pk)
 
     def get_object(self, **kwargs):
         return Scenario.objects.get(pk=self.kwargs.get("pk"))
@@ -442,9 +442,16 @@ class InventoryAlgorithmParametersAPIView(APIView):
         return Response(serializer.data)
 
 
+@login_required
 def download_scenario_summary(request, scenario_pk):
+    try:
+        scenario = Scenario.objects.get(id=scenario_pk)
+    except Scenario.DoesNotExist:
+        raise Http404
+    policy = get_object_policy(request.user, scenario, request=request)
+    if not (policy["is_owner"] or policy["is_published"] or request.user.is_staff):
+        return HttpResponseForbidden()
     file_name = f"scenario_{scenario_pk}_summary.json"
-    scenario = Scenario.objects.get(id=scenario_pk)
     with io.StringIO(json.dumps(scenario.summary_dict(), indent=4)) as file:
         response = HttpResponse(file, content_type="application/json")
         response["Content-Disposition"] = f"attachment; filename={file_name}"
@@ -551,8 +558,15 @@ class ScenarioResultDetailMapView(MapMixin, DetailView):
         return f"{self.object.scenario.name}: {self.object.algorithm.geodataset.name}"
 
 
+@login_required
 def download_scenario_result_summary(request, scenario_pk):
-    scenario = Scenario.objects.get(id=scenario_pk)
+    try:
+        scenario = Scenario.objects.get(id=scenario_pk)
+    except Scenario.DoesNotExist:
+        raise Http404
+    policy = get_object_policy(request.user, scenario, request=request)
+    if not (policy["is_owner"] or policy["is_published"] or request.user.is_staff):
+        return HttpResponseForbidden()
     result = ScenarioResult(scenario)
     with io.StringIO(json.dumps(result.summary_dict(), indent=4)) as file:
         response = HttpResponse(file, content_type="application/json")

--- a/inventories/views.py
+++ b/inventories/views.py
@@ -256,13 +256,12 @@ class ScenarioAlgorithmConfigurationUpdateView(
         policy = get_object_policy(self.request.user, scenario, request=self.request)
         return policy["can_edit"]
 
-    @staticmethod
-    def post(request, *args, **kwargs):
-        scenario = Scenario.objects.get(id=request.POST.get("scenario"))
+    def post(self, request, *args, **kwargs):
+        scenario = Scenario.objects.get(id=self.kwargs.get("scenario_pk"))
         current_algorithm = InventoryAlgorithm.objects.get(
-            id=kwargs.get("algorithm_pk")
+            id=self.kwargs.get("algorithm_pk")
         )
-        current_feedstock = SampleSeries.objects.get(id=kwargs.get("feedstock_pk"))
+        current_feedstock = SampleSeries.objects.get(id=self.kwargs.get("feedstock_pk"))
         scenario.remove_inventory_algorithm(current_algorithm, current_feedstock)
         feedstock = SampleSeries.objects.get(id=request.POST.get("feedstock"))
         new_algorithm = InventoryAlgorithm.objects.get(
@@ -279,7 +278,7 @@ class ScenarioAlgorithmConfigurationUpdateView(
                     InventoryAlgorithmParameterValue.objects.get(id=value_id)
                 )
         scenario.add_inventory_algorithm(feedstock, new_algorithm, values)
-        return redirect("scenario-detail", pk=request.POST.get("scenario"))
+        return redirect("scenario-detail", pk=scenario.pk)
 
     def get_object(self, **kwargs):
         return Scenario.objects.get(pk=self.kwargs.get("scenario_pk"))
@@ -447,9 +446,9 @@ def download_scenario_summary(request, scenario_pk):
     try:
         scenario = Scenario.objects.get(id=scenario_pk)
     except Scenario.DoesNotExist:
-        raise Http404
+        raise Http404 from None
     policy = get_object_policy(request.user, scenario, request=request)
-    if not (policy["is_owner"] or policy["is_published"] or request.user.is_staff):
+    if not (policy["is_owner"] or policy["is_published"] or policy["is_staff"]):
         return HttpResponseForbidden()
     file_name = f"scenario_{scenario_pk}_summary.json"
     with io.StringIO(json.dumps(scenario.summary_dict(), indent=4)) as file:
@@ -563,9 +562,9 @@ def download_scenario_result_summary(request, scenario_pk):
     try:
         scenario = Scenario.objects.get(id=scenario_pk)
     except Scenario.DoesNotExist:
-        raise Http404
+        raise Http404 from None
     policy = get_object_policy(request.user, scenario, request=request)
-    if not (policy["is_owner"] or policy["is_published"] or request.user.is_staff):
+    if not (policy["is_owner"] or policy["is_published"] or policy["is_staff"]):
         return HttpResponseForbidden()
     result = ScenarioResult(scenario)
     with io.StringIO(json.dumps(result.summary_dict(), indent=4)) as file:

--- a/inventories/views.py
+++ b/inventories/views.py
@@ -448,7 +448,7 @@ def download_scenario_summary(request, scenario_pk):
     except Scenario.DoesNotExist:
         raise Http404 from None
     policy = get_object_policy(request.user, scenario, request=request)
-    if not (policy["is_owner"] or policy["is_published"] or policy["is_staff"]):
+    if not (policy["is_owner"] or policy["is_published"] or policy["is_staff"] or policy["is_moderator"]):
         return HttpResponseForbidden()
     file_name = f"scenario_{scenario_pk}_summary.json"
     with io.StringIO(json.dumps(scenario.summary_dict(), indent=4)) as file:
@@ -564,7 +564,7 @@ def download_scenario_result_summary(request, scenario_pk):
     except Scenario.DoesNotExist:
         raise Http404 from None
     policy = get_object_policy(request.user, scenario, request=request)
-    if not (policy["is_owner"] or policy["is_published"] or policy["is_staff"]):
+    if not (policy["is_owner"] or policy["is_published"] or policy["is_staff"] or policy["is_moderator"]):
         return HttpResponseForbidden()
     result = ScenarioResult(scenario)
     with io.StringIO(json.dumps(result.summary_dict(), indent=4)) as file:

--- a/inventories/views.py
+++ b/inventories/views.py
@@ -448,7 +448,12 @@ def download_scenario_summary(request, scenario_pk):
     except Scenario.DoesNotExist:
         raise Http404 from None
     policy = get_object_policy(request.user, scenario, request=request)
-    if not (policy["is_owner"] or policy["is_published"] or policy["is_staff"] or policy["is_moderator"]):
+    if not (
+        policy["is_owner"]
+        or policy["is_published"]
+        or policy["is_staff"]
+        or policy["is_moderator"]
+    ):
         return HttpResponseForbidden()
     file_name = f"scenario_{scenario_pk}_summary.json"
     with io.StringIO(json.dumps(scenario.summary_dict(), indent=4)) as file:
@@ -564,7 +569,12 @@ def download_scenario_result_summary(request, scenario_pk):
     except Scenario.DoesNotExist:
         raise Http404 from None
     policy = get_object_policy(request.user, scenario, request=request)
-    if not (policy["is_owner"] or policy["is_published"] or policy["is_staff"] or policy["is_moderator"]):
+    if not (
+        policy["is_owner"]
+        or policy["is_published"]
+        or policy["is_staff"]
+        or policy["is_moderator"]
+    ):
         return HttpResponseForbidden()
     result = ScenarioResult(scenario)
     with io.StringIO(json.dumps(result.summary_dict(), indent=4)) as file:


### PR DESCRIPTION
Fixes #204 and #205.

## Changes

**Issue #204 — unauthenticated endpoints:**
- `download_scenario_summary` and `download_scenario_result_summary`: added `@login_required` + object-level policy check (`is_owner`, `is_published`, `is_staff`, or `is_moderator`)
- `get_evaluation_status`: added `@login_required`

**Issue #205 — authorization bypass in `ScenarioAddInventoryAlgorithmView`:**
- Removed `@staticmethod` from `post()` so it receives `self`
- Changed `post()` to read the scenario from `self.kwargs["pk"]` (URL) instead of `request.POST["scenario"]` (body), ensuring the permission-checked scenario is the one modified

**Same bypass fixed in `ScenarioAlgorithmConfigurationUpdateView`:**
- Removed `@staticmethod` from `post()`, changed it to read scenario from `self.kwargs["scenario_pk"]` instead of `request.POST["scenario"]`
- Redirect now uses `scenario.pk` instead of POST body value

```python
# Before (bypass: test_func checks URL pk, post reads POST body)
@staticmethod
def post(request, *args, **kwargs):
    scenario_id = request.POST.get("scenario")
    scenario = Scenario.objects.get(id=scenario_id)

# After (post uses the same pk that test_func checked)
def post(self, request, *args, **kwargs):
    scenario = Scenario.objects.get(id=self.kwargs.get("pk"))
```

**Additional fixes from review:**
- Use `policy["is_staff"]` instead of `request.user.is_staff` to correctly cover superusers without the staff flag
- Include `policy["is_moderator"]` in download authorization checks, consistent with `_check_safe_permissions` read-access policy

## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Verification

- [x] Focused tests or checks were run.
  - `inventories.tests.test_views` — 213 tests, 0 failures
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed. (N/A)
- [x] No secrets, raw data, or production-only configuration are included.

Link to Devin session: https://app.devin.ai/sessions/b17f24bdc3e84ce3b211c6199db19156
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->