### PR TITLE
Fix view-level access control gaps (#206, #209, #214, #217)

### DIFF
--- a/bibliography/tests/test_views.py
+++ b/bibliography/tests/test_views.py
@@ -356,6 +356,9 @@ class SourceCRUDViewsTestCase(AbstractTestCases.UserCreatedObjectCRUDViewTestCas
         """
         Test updating a Source that was created with no authors to add one or more authors.
         """
+        self.user_with_add_perm.user_permissions.add(
+            Permission.objects.get(codename="change_source")
+        )
         self.client.force_login(self.user_with_add_perm)
         post_data = self.create_object_data.copy()
         # Create Source with no authors

--- a/materials/tests/test_views.py
+++ b/materials/tests/test_views.py
@@ -923,6 +923,9 @@ class MaterialPropertyValueUpdateViewTestCase(ViewWithPermissionsTestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
+        cls.owner.user_permissions.add(
+            Permission.objects.get(codename="change_materialpropertyvalue")
+        )
         cls.unit = Unit.objects.create(name="mg/L", owner=cls.owner)
         cls.default_basis = MaterialComponent.objects.create(
             owner=cls.owner,
@@ -1192,6 +1195,9 @@ class ComponentMeasurementUpdateViewTestCase(ViewWithPermissionsTestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
+        cls.owner.user_permissions.add(
+            Permission.objects.get(codename="change_componentmeasurement")
+        )
         cls.unit = Unit.objects.filter(name="%").first()
         if cls.unit is None:
             cls.unit = Unit.objects.create(
@@ -2415,6 +2421,9 @@ class SampleCreateDuplicateViewTestCase(ViewWithPermissionsTestCase):
             material=cls.material,
             series=cls.series,
             timestep=timestep,
+        )
+        cls.sample.owner.user_permissions.add(
+            Permission.objects.get(codename="change_sample")
         )
 
     def test_get_http_302_redirect_to_login_for_anonymous(self):

--- a/materials/tests/test_views.py
+++ b/materials/tests/test_views.py
@@ -2212,6 +2212,27 @@ class SampleAddPropertyViewTestCase(ViewWithPermissionsTestCase):
         )
         self.assertEqual(value.basis_component, self.selected_basis)
 
+    def test_get_http_403_for_non_owner_with_permission(self):
+        """Non-owner with add_materialpropertyvalue should be denied (#206)."""
+        self.client.force_login(self.member)
+        response = self.client.get(
+            reverse("sample-add-property", kwargs={"pk": self.sample.pk})
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_post_http_403_for_non_owner_with_permission(self):
+        """Non-owner with add_materialpropertyvalue should be denied on POST (#206)."""
+        self.client.force_login(self.member)
+        data = {
+            "property": self.property.pk,
+            "average": 99.0,
+            "standard_deviation": 1.0,
+        }
+        response = self.client.post(
+            reverse("sample-add-property", kwargs={"pk": self.sample.pk}), data
+        )
+        self.assertEqual(response.status_code, 403)
+
 
 class SampleModalAddPropertyViewTestCase(ViewWithPermissionsTestCase):
     member_permissions = "add_materialpropertyvalue"

--- a/materials/views.py
+++ b/materials/views.py
@@ -1366,9 +1366,17 @@ class SampleAddCompositionView(UserCreatedObjectCreateView):
         return super().post(request, *args, **kwargs)
 
 
-class SampleAddPropertyView(UserCreatedObjectCreateView):
+class SampleAddPropertyView(UserPassesTestMixin, UserCreatedObjectCreateView):
     form_class = MaterialPropertyValueModelForm
     permission_required = "materials.add_materialpropertyvalue"
+
+    def test_func(self):
+        try:
+            sample = Sample.objects.get(pk=self.kwargs.get("pk"))
+        except Sample.DoesNotExist:
+            return False
+        policy = get_object_policy(self.request.user, sample, request=self.request)
+        return policy["can_add_property"]
 
     def form_valid(self, form):
         sample = Sample.objects.get(pk=self.kwargs.get("pk"))

--- a/sources/greenhouses/tests/test_views.py
+++ b/sources/greenhouses/tests/test_views.py
@@ -144,6 +144,39 @@ class GrowthCycleCRUDViewsTestCase(AbstractTestCases.UserCreatedObjectCRUDViewTe
         )
 
 
+class GreenhouseUpdateViewPermissionTestCase(ViewWithPermissionsTestCase):
+    """#209: GreenhouseUpdateView must require change_greenhouse permission."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.greenhouse = Greenhouse.objects.create(
+            owner=cls.owner, name="Test Greenhouse", publication_status="private"
+        )
+
+    def test_get_http_403_for_owner_without_change_permission(self):
+        self.client.force_login(self.owner)
+        url = reverse("greenhouse-update", kwargs={"pk": self.greenhouse.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_get_http_200_for_owner_with_change_permission(self):
+        from django.contrib.auth.models import Permission
+
+        perm = Permission.objects.get(codename="change_greenhouse")
+        self.owner.user_permissions.add(perm)
+        self.client.force_login(self.owner)
+        url = reverse("greenhouse-update", kwargs={"pk": self.greenhouse.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_http_200_for_staff_without_explicit_permission(self):
+        self.client.force_login(self.staff)
+        url = reverse("greenhouse-update", kwargs={"pk": self.greenhouse.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+
 class GreenhouseDetailPermissionRegressionTest(ViewWithPermissionsTestCase):
     member_permissions = "add_greenhousegrowthcycle"
 

--- a/sources/greenhouses/views.py
+++ b/sources/greenhouses/views.py
@@ -123,11 +123,13 @@ class GreenhouseDetailView(UserCreatedObjectDetailView):
 class GreenhouseUpdateView(UserCreatedObjectUpdateView):
     model = Greenhouse
     form_class = GreenhouseModelForm
+    permission_required = "greenhouses.change_greenhouse"
 
 
 class GreenhouseModalUpdateView(UserCreatedObjectModalUpdateView):
     model = Greenhouse
     form_class = GreenhouseModalModelForm
+    permission_required = "greenhouses.change_greenhouse"
 
 
 class GreenhouseModalDeleteView(UserCreatedObjectModalDeleteView):

--- a/sources/greenhouses/views.py
+++ b/sources/greenhouses/views.py
@@ -123,13 +123,11 @@ class GreenhouseDetailView(UserCreatedObjectDetailView):
 class GreenhouseUpdateView(UserCreatedObjectUpdateView):
     model = Greenhouse
     form_class = GreenhouseModelForm
-    permission_required = "greenhouses.change_greenhouse"
 
 
 class GreenhouseModalUpdateView(UserCreatedObjectModalUpdateView):
     model = Greenhouse
     form_class = GreenhouseModalModelForm
-    permission_required = "greenhouses.change_greenhouse"
 
 
 class GreenhouseModalDeleteView(UserCreatedObjectModalDeleteView):

--- a/sources/waste_collection/tests/test_views.py
+++ b/sources/waste_collection/tests/test_views.py
@@ -1098,6 +1098,14 @@ class CollectionCatchmentCRUDViewsTestCase(
     update_object_data = {"name": "Updated Test Catchment"}
 
     @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        # The update view operates on the concrete Catchment model
+        cls.owner_user.user_permissions.add(
+            Permission.objects.get(codename="change_catchment")
+        )
+
+    @classmethod
     def create_related_objects(cls):
         return {
             "region": Region.objects.create(

--- a/sources/waste_collection/tests/test_views.py
+++ b/sources/waste_collection/tests/test_views.py
@@ -149,6 +149,87 @@ class CollectorCRUDViewsTestCase(AbstractTestCases.UserCreatedObjectCRUDViewTest
     update_object_data = {"name": "Updated Test Collector"}
 
 
+class CollectorUpdateViewPermissionTestCase(ViewWithPermissionsTestCase):
+    """#209: CollectorUpdateView must require change_collector permission."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.collector = Collector.objects.create(
+            owner=cls.owner, name="Test Collector", publication_status="private"
+        )
+
+    def test_get_http_403_for_owner_without_change_permission(self):
+        self.client.force_login(self.owner)
+        url = reverse("collector-update", kwargs={"pk": self.collector.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_get_http_200_for_owner_with_change_permission(self):
+        perm = Permission.objects.get(codename="change_collector")
+        self.owner.user_permissions.add(perm)
+        self.client.force_login(self.owner)
+        url = reverse("collector-update", kwargs={"pk": self.collector.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_http_200_for_staff_without_explicit_permission(self):
+        self.client.force_login(self.staff)
+        url = reverse("collector-update", kwargs={"pk": self.collector.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+
+class CollectionSystemUpdateViewPermissionTestCase(ViewWithPermissionsTestCase):
+    """#209: CollectionSystemUpdateView must require change_collectionsystem."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.obj = CollectionSystem.objects.create(
+            owner=cls.owner, name="Test System", publication_status="private"
+        )
+
+    def test_get_http_403_for_owner_without_change_permission(self):
+        self.client.force_login(self.owner)
+        url = reverse("collectionsystem-update", kwargs={"pk": self.obj.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_get_http_200_for_owner_with_change_permission(self):
+        perm = Permission.objects.get(codename="change_collectionsystem")
+        self.owner.user_permissions.add(perm)
+        self.client.force_login(self.owner)
+        url = reverse("collectionsystem-update", kwargs={"pk": self.obj.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+
+class WasteCategoryUpdateViewPermissionTestCase(ViewWithPermissionsTestCase):
+    """#209: WasteCategoryUpdateView must require change_wastecategory."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.obj = WasteCategory.objects.create(
+            owner=cls.owner, name="Test Category", publication_status="private"
+        )
+
+    def test_get_http_403_for_owner_without_change_permission(self):
+        self.client.force_login(self.owner)
+        url = reverse("wastecategory-update", kwargs={"pk": self.obj.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_get_http_200_for_owner_with_change_permission(self):
+        perm = Permission.objects.get(codename="change_wastecategory")
+        self.owner.user_permissions.add(perm)
+        self.client.force_login(self.owner)
+        url = reverse("wastecategory-update", kwargs={"pk": self.obj.pk})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+
 class CollectorListScopeRegressionTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
@@ -2369,6 +2450,84 @@ class CollectionAddPropertyValueViewTestCase(ViewWithPermissionsTestCase):
             year=2022,
         )
         self.assertEqual(list(cpv.sources.values_list("pk", flat=True)), [source.pk])
+
+
+class CollectionAddPropertyValueViewDispatchOrderTestCase(ViewWithPermissionsTestCase):
+    """#217: Permission check must run before parent dispatch to prevent side effects."""
+
+    member_permissions = "add_collectionpropertyvalue"
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.private_collection = Collection.objects.create(
+            name="Private Collection",
+            publication_status="private",
+            owner=cls.owner,
+        )
+        cls.unit = Unit.objects.create(name="Test Unit", publication_status="published")
+        cls.prop = Property.objects.create(
+            name="Test Property", publication_status="published"
+        )
+        cls.prop.allowed_units.add(cls.unit)
+
+    def test_post_valid_data_as_non_owner_blocked_without_db_write(self):
+        """Valid POST by non-owner must be blocked before saving (#217)."""
+        self.client.force_login(self.member)
+        url = reverse(
+            "collection-add-property", kwargs={"pk": self.private_collection.pk}
+        )
+        data = {
+            "collection": self.private_collection.pk,
+            "property": self.prop.pk,
+            "unit": self.unit.pk,
+            "year": 2023,
+            "average": 50.0,
+            "standard_deviation": 5.0,
+            "form-TOTAL_FORMS": "0",
+            "form-INITIAL_FORMS": "0",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+        }
+        initial_count = CollectionPropertyValue.objects.count()
+        response = self.client.post(url, data=data)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(
+            CollectionPropertyValue.objects.count(),
+            initial_count,
+            "No CPV should be created when permission is denied",
+        )
+
+
+class SelectNewlyCreatedObjectModelSelectOptionsViewTestCase(
+    ViewWithPermissionsTestCase,
+):
+    """#214: get_selected_object must filter by owner, not global max(created_at)."""
+
+    member_permissions = "view_collector"
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        perm = Permission.objects.get(codename="view_collector")
+        cls.owner.user_permissions.add(perm)
+        cls.own_collector = Collector.objects.create(
+            owner=cls.owner, name="Owner Collector"
+        )
+        cls.other_collector = Collector.objects.create(
+            owner=cls.member, name="Member Collector"
+        )
+
+    def test_get_selected_object_returns_own_object(self):
+        """Selected object must belong to the requesting user, not be global max (#214)."""
+        request = RequestFactory().get(reverse("collector-options"))
+        request.user = self.owner
+        view = views.CollectorOptions()
+        view.setup(request)
+        view.kwargs = {}
+        view.model = Collector
+        selected = view.get_selected_object()
+        self.assertEqual(selected.owner, self.owner)
 
 
 class CollectionAddAggregatedPropertyValueViewTestCase(ViewWithPermissionsTestCase):

--- a/sources/waste_collection/views.py
+++ b/sources/waste_collection/views.py
@@ -6,7 +6,11 @@ from urllib.parse import urlencode
 
 from celery.result import AsyncResult
 from django.contrib import messages
-from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
+from django.contrib.auth.mixins import (
+    LoginRequiredMixin,
+    PermissionRequiredMixin,
+    UserPassesTestMixin,
+)
 from django.core.exceptions import PermissionDenied
 from django.db.models import Count, Max, Min, Prefetch, Q
 from django.forms.models import model_to_dict
@@ -259,11 +263,13 @@ class CollectorModalDetailView(UserCreatedObjectModalDetailView):
 class CollectorUpdateView(UserCreatedObjectUpdateView):
     model = Collector
     form_class = CollectorModelForm
+    permission_required = "waste_collection.change_collector"
 
 
 class CollectorModalUpdateView(UserCreatedObjectModalUpdateView):
     model = Collector
     form_class = CollectorModalModelForm
+    permission_required = "waste_collection.change_collector"
 
 
 class CollectorModalDeleteView(UserCreatedObjectModalDeleteView):
@@ -319,11 +325,13 @@ class CollectionSystemModalDetailView(UserCreatedObjectModalDetailView):
 class CollectionSystemUpdateView(UserCreatedObjectUpdateView):
     model = CollectionSystem
     form_class = CollectionSystemModelForm
+    permission_required = "waste_collection.change_collectionsystem"
 
 
 class CollectionSystemModalUpdateView(UserCreatedObjectModalUpdateView):
     model = CollectionSystem
     form_class = CollectionSystemModalModelForm
+    permission_required = "waste_collection.change_collectionsystem"
 
 
 class CollectionSystemModalDeleteView(UserCreatedObjectModalDeleteView):
@@ -371,11 +379,13 @@ class WasteCategoryModalDetailView(UserCreatedObjectModalDetailView):
 class WasteCategoryUpdateView(UserCreatedObjectUpdateView):
     model = WasteCategory
     form_class = WasteCategoryModelForm
+    permission_required = "waste_collection.change_wastecategory"
 
 
 class WasteCategoryModalUpdateView(UserCreatedObjectModalUpdateView):
     model = WasteCategory
     form_class = WasteCategoryModalModelForm
+    permission_required = "waste_collection.change_wastecategory"
 
 
 class WasteCategoryModalDeleteView(UserCreatedObjectModalDeleteView):
@@ -1761,32 +1771,25 @@ class CollectionListFileExportView(GenericUserCreatedObjectExportView):
     include_row_count_estimate = True
 
 
-class CollectionAddPropertyValueView(CollectionPropertyValueCreateView):
-    # TODO: Handle permissions without overriding dispatch
-    def dispatch(self, request, *args, **kwargs):
-        # Let parent handle authentication first
-        result = super().dispatch(request, *args, **kwargs)
-
-        # Only check policy for authenticated requests that passed parent checks
-        if request.user.is_authenticated and request.method in ("GET", "POST"):
-            try:
-                self.parent_collection = Collection.objects.get(pk=kwargs.get("pk"))
-            except Collection.DoesNotExist as err:
-                raise PermissionDenied("Invalid parent collection.") from err
-
-            policy = get_object_policy(
-                request.user, self.parent_collection, request=request
+class CollectionAddPropertyValueView(
+    UserPassesTestMixin, CollectionPropertyValueCreateView
+):
+    def test_func(self):
+        try:
+            self.parent_collection = Collection.objects.get(
+                pk=self.kwargs.get("pk")
             )
-            if not policy.get("can_add_property"):
-                raise PermissionDenied(
-                    "You do not have permission to add statistics to this collection."
-                )
-
-            self.anchor_collection = (
-                self.parent_collection.version_anchor or self.parent_collection
-            )
-
-        return result
+        except Collection.DoesNotExist:
+            raise PermissionDenied("Invalid parent collection.")
+        policy = get_object_policy(
+            self.request.user, self.parent_collection, request=self.request
+        )
+        if not policy.get("can_add_property"):
+            return False
+        self.anchor_collection = (
+            self.parent_collection.version_anchor or self.parent_collection
+        )
+        return True
 
     def get_initial(self):
         initial = super().get_initial()
@@ -1825,11 +1828,11 @@ class CollectionCatchmentAddAggregatedPropertyView(
 
 class SelectNewlyCreatedObjectModelSelectOptionsView(OwnedObjectModelSelectOptionsView):
     def get_selected_object(self):
-        # TODO: Improve this by adding owner to
-        created_at = self.model.objects.aggregate(max_created_at=Max("created_at"))[
-            "max_created_at"
-        ]
-        return self.model.objects.get(created_at=created_at)
+        qs = self.model.objects.filter(owner=self.request.user)
+        created_at = qs.aggregate(max_created_at=Max("created_at"))["max_created_at"]
+        if created_at is None:
+            return None
+        return qs.filter(created_at=created_at).first()
 
 
 class CollectorOptions(SelectNewlyCreatedObjectModelSelectOptionsView):

--- a/sources/waste_collection/views.py
+++ b/sources/waste_collection/views.py
@@ -1772,7 +1772,7 @@ class CollectionAddPropertyValueView(
         try:
             self.parent_collection = Collection.objects.get(pk=self.kwargs.get("pk"))
         except Collection.DoesNotExist:
-            raise PermissionDenied("Invalid parent collection.") from None
+            return False
         policy = get_object_policy(
             self.request.user, self.parent_collection, request=self.request
         )

--- a/sources/waste_collection/views.py
+++ b/sources/waste_collection/views.py
@@ -1780,7 +1780,7 @@ class CollectionAddPropertyValueView(
                 pk=self.kwargs.get("pk")
             )
         except Collection.DoesNotExist:
-            raise PermissionDenied("Invalid parent collection.")
+            raise PermissionDenied("Invalid parent collection.") from None
         policy = get_object_policy(
             self.request.user, self.parent_collection, request=self.request
         )

--- a/sources/waste_collection/views.py
+++ b/sources/waste_collection/views.py
@@ -263,13 +263,11 @@ class CollectorModalDetailView(UserCreatedObjectModalDetailView):
 class CollectorUpdateView(UserCreatedObjectUpdateView):
     model = Collector
     form_class = CollectorModelForm
-    permission_required = "waste_collection.change_collector"
 
 
 class CollectorModalUpdateView(UserCreatedObjectModalUpdateView):
     model = Collector
     form_class = CollectorModalModelForm
-    permission_required = "waste_collection.change_collector"
 
 
 class CollectorModalDeleteView(UserCreatedObjectModalDeleteView):
@@ -325,13 +323,11 @@ class CollectionSystemModalDetailView(UserCreatedObjectModalDetailView):
 class CollectionSystemUpdateView(UserCreatedObjectUpdateView):
     model = CollectionSystem
     form_class = CollectionSystemModelForm
-    permission_required = "waste_collection.change_collectionsystem"
 
 
 class CollectionSystemModalUpdateView(UserCreatedObjectModalUpdateView):
     model = CollectionSystem
     form_class = CollectionSystemModalModelForm
-    permission_required = "waste_collection.change_collectionsystem"
 
 
 class CollectionSystemModalDeleteView(UserCreatedObjectModalDeleteView):
@@ -379,13 +375,11 @@ class WasteCategoryModalDetailView(UserCreatedObjectModalDetailView):
 class WasteCategoryUpdateView(UserCreatedObjectUpdateView):
     model = WasteCategory
     form_class = WasteCategoryModelForm
-    permission_required = "waste_collection.change_wastecategory"
 
 
 class WasteCategoryModalUpdateView(UserCreatedObjectModalUpdateView):
     model = WasteCategory
     form_class = WasteCategoryModalModelForm
-    permission_required = "waste_collection.change_wastecategory"
 
 
 class WasteCategoryModalDeleteView(UserCreatedObjectModalDeleteView):

--- a/sources/waste_collection/views.py
+++ b/sources/waste_collection/views.py
@@ -1776,9 +1776,7 @@ class CollectionAddPropertyValueView(
 ):
     def test_func(self):
         try:
-            self.parent_collection = Collection.objects.get(
-                pk=self.kwargs.get("pk")
-            )
+            self.parent_collection = Collection.objects.get(pk=self.kwargs.get("pk"))
         except Collection.DoesNotExist:
             raise PermissionDenied("Invalid parent collection.") from None
         policy = get_object_policy(

--- a/utils/object_management/mixins.py
+++ b/utils/object_management/mixins.py
@@ -55,7 +55,12 @@ class _BaseUserCreatedObjectAccessMixin(UserPassesTestMixin):
             return True
         # Fallback for models without update URLs in the policy
         return not policy["is_archived"] and (
-            policy["is_staff"] or (policy["is_owner"] and not policy["is_published"])
+            policy["is_staff"]
+            or (
+                policy["is_owner"]
+                and not policy["is_published"]
+                and policy["has_change_permission"]
+            )
         )
 
 

--- a/utils/object_management/permissions.py
+++ b/utils/object_management/permissions.py
@@ -440,11 +440,25 @@ def get_object_policy(user, obj, request=None, review_mode=False):
         getattr(obj, "modal_delete_url", None) or getattr(obj, "delete_url", None)
     )
 
-    # Edit: staff always; owners if not published; never when archived
+    # Model-level change permission (change_<modelname>), staff always pass
+    try:
+        _meta = obj.__class__._meta
+        change_perm = f"{_meta.app_label}.change_{_meta.model_name}"
+        has_change_permission = is_staff or bool(
+            is_authenticated and user.has_perm(change_perm)
+        )
+    except Exception:
+        logger.exception(
+            "Failed checking change permission in get_object_policy", exc_info=True
+        )
+        has_change_permission = is_staff
+
+    # Edit: staff always; owners with change permission if not published;
+    # never when archived
     can_edit = (
         has_update_url
         and not is_archived
-        and (is_staff or (is_owner and not is_published))
+        and (is_staff or (is_owner and not is_published and has_change_permission))
     )
 
     # Delete:
@@ -534,6 +548,7 @@ def get_object_policy(user, obj, request=None, review_mode=False):
         "is_published": is_published,
         "is_declined": is_declined,
         "is_archived": is_archived,
+        "has_change_permission": has_change_permission,
         "can_edit": can_edit,
         "can_manage_samples": can_manage_samples,
         "can_add_property": can_add_property,

--- a/utils/object_management/views.py
+++ b/utils/object_management/views.py
@@ -2275,9 +2275,14 @@ class UserCreatedObjectModalDetailView(
 
 
 class UserCreatedObjectUpdateView(
-    UserCreatedObjectWriteAccessMixin, NextOrSuccessUrlMixin, UpdateView
+    PermissionRequiredMixin, UserCreatedObjectWriteAccessMixin, NextOrSuccessUrlMixin, UpdateView
 ):
-    # TODO: Implement permission flow for publication process and moderators.
+    permission_required = ()
+
+    def has_permission(self):
+        if self.request.user.is_staff:
+            return True
+        return super().has_permission()
 
     def get_form_kwargs(self):
         """Pass request to form if it supports UserCreatedObjectFormMixin or SourcesFieldMixin."""
@@ -2382,9 +2387,15 @@ class UserCreatedObjectCreateWithInlinesView(
 
 
 class UserCreatedObjectUpdateWithInlinesView(
-    UserCreatedObjectWriteAccessMixin, NextOrSuccessUrlMixin, UpdateWithInlinesView
+    PermissionRequiredMixin, UserCreatedObjectWriteAccessMixin, NextOrSuccessUrlMixin, UpdateWithInlinesView
 ):
+    permission_required = ()
     formset_helper_class = DynamicTableInlineFormSetHelper
+
+    def has_permission(self):
+        if self.request.user.is_staff:
+            return True
+        return super().has_permission()
 
     def get_form_kwargs(self):
         """Pass request to form if it supports UserCreatedObjectFormMixin or SourcesFieldMixin."""
@@ -2437,10 +2448,16 @@ class UserCreatedObjectUpdateWithInlinesView(
 
 
 class UserCreatedObjectModalUpdateView(
-    UserCreatedObjectWriteAccessMixin, NextOrSuccessUrlMixin, BSModalUpdateView
+    PermissionRequiredMixin, UserCreatedObjectWriteAccessMixin, NextOrSuccessUrlMixin, BSModalUpdateView
 ):
+    permission_required = ()
     template_name = "modal_form.html"
     success_message = "Successfully updated."
+
+    def has_permission(self):
+        if self.request.user.is_staff:
+            return True
+        return super().has_permission()
 
     def get_form_kwargs(self):
         """Pass request to form if it supports UserCreatedObjectFormMixin or SourcesFieldMixin."""

--- a/utils/object_management/views.py
+++ b/utils/object_management/views.py
@@ -1814,6 +1814,7 @@ class UserCreatedObjectWriteAccessMixin(UserPassesTestMixin):
     owner_field = "owner"
     published_status = "published"
     permission_denied_message = "You do not have permission to access this object."
+    object_policy_action = "edit"
 
     def test_func(self):
         user = self.request.user
@@ -1840,11 +1841,26 @@ class UserCreatedObjectWriteAccessMixin(UserPassesTestMixin):
             )
 
         policy = get_object_policy(user, obj, request=self.request)
+        if self.object_policy_action == "delete":
+            if policy["can_delete"]:
+                return True
+            # Fallback for models without delete URLs in the policy
+            return not policy["is_archived"] and (
+                policy["is_staff"]
+                or (policy["is_owner"] and not policy["is_published"])
+            )
+
         if policy["can_edit"]:
             return True
 
+        # Fallback for models without update URLs in the policy
         return not policy["is_archived"] and (
-            policy["is_staff"] or (policy["is_owner"] and not policy["is_published"])
+            policy["is_staff"]
+            or (
+                policy["is_owner"]
+                and not policy["is_published"]
+                and policy["has_change_permission"]
+            )
         )
 
 
@@ -2275,18 +2291,8 @@ class UserCreatedObjectModalDetailView(
 
 
 class UserCreatedObjectUpdateView(
-    PermissionRequiredMixin,
-    UserCreatedObjectWriteAccessMixin,
-    NextOrSuccessUrlMixin,
-    UpdateView,
+    UserCreatedObjectWriteAccessMixin, NextOrSuccessUrlMixin, UpdateView
 ):
-    permission_required = ()
-
-    def has_permission(self):
-        if self.request.user.is_staff:
-            return True
-        return super().has_permission()
-
     def get_form_kwargs(self):
         """Pass request to form if it supports UserCreatedObjectFormMixin or SourcesFieldMixin."""
         kwargs = super().get_form_kwargs()
@@ -2390,18 +2396,9 @@ class UserCreatedObjectCreateWithInlinesView(
 
 
 class UserCreatedObjectUpdateWithInlinesView(
-    PermissionRequiredMixin,
-    UserCreatedObjectWriteAccessMixin,
-    NextOrSuccessUrlMixin,
-    UpdateWithInlinesView,
+    UserCreatedObjectWriteAccessMixin, NextOrSuccessUrlMixin, UpdateWithInlinesView
 ):
-    permission_required = ()
     formset_helper_class = DynamicTableInlineFormSetHelper
-
-    def has_permission(self):
-        if self.request.user.is_staff:
-            return True
-        return super().has_permission()
 
     def get_form_kwargs(self):
         """Pass request to form if it supports UserCreatedObjectFormMixin or SourcesFieldMixin."""
@@ -2454,19 +2451,10 @@ class UserCreatedObjectUpdateWithInlinesView(
 
 
 class UserCreatedObjectModalUpdateView(
-    PermissionRequiredMixin,
-    UserCreatedObjectWriteAccessMixin,
-    NextOrSuccessUrlMixin,
-    BSModalUpdateView,
+    UserCreatedObjectWriteAccessMixin, NextOrSuccessUrlMixin, BSModalUpdateView
 ):
-    permission_required = ()
     template_name = "modal_form.html"
     success_message = "Successfully updated."
-
-    def has_permission(self):
-        if self.request.user.is_staff:
-            return True
-        return super().has_permission()
 
     def get_form_kwargs(self):
         """Pass request to form if it supports UserCreatedObjectFormMixin or SourcesFieldMixin."""
@@ -2534,6 +2522,7 @@ class UserCreatedObjectModalArchiveView(
 class UserCreatedObjectModalDeleteView(
     UserCreatedObjectWriteAccessMixin, NextOrSuccessUrlMixin, BSModalDeleteView
 ):
+    object_policy_action = "delete"
     template_name = "modal_delete.html"
     success_message = "Successfully deleted."
 

--- a/utils/object_management/views.py
+++ b/utils/object_management/views.py
@@ -2275,7 +2275,10 @@ class UserCreatedObjectModalDetailView(
 
 
 class UserCreatedObjectUpdateView(
-    PermissionRequiredMixin, UserCreatedObjectWriteAccessMixin, NextOrSuccessUrlMixin, UpdateView
+    PermissionRequiredMixin,
+    UserCreatedObjectWriteAccessMixin,
+    NextOrSuccessUrlMixin,
+    UpdateView,
 ):
     permission_required = ()
 
@@ -2387,7 +2390,10 @@ class UserCreatedObjectCreateWithInlinesView(
 
 
 class UserCreatedObjectUpdateWithInlinesView(
-    PermissionRequiredMixin, UserCreatedObjectWriteAccessMixin, NextOrSuccessUrlMixin, UpdateWithInlinesView
+    PermissionRequiredMixin,
+    UserCreatedObjectWriteAccessMixin,
+    NextOrSuccessUrlMixin,
+    UpdateWithInlinesView,
 ):
     permission_required = ()
     formset_helper_class = DynamicTableInlineFormSetHelper
@@ -2448,7 +2454,10 @@ class UserCreatedObjectUpdateWithInlinesView(
 
 
 class UserCreatedObjectModalUpdateView(
-    PermissionRequiredMixin, UserCreatedObjectWriteAccessMixin, NextOrSuccessUrlMixin, BSModalUpdateView
+    PermissionRequiredMixin,
+    UserCreatedObjectWriteAccessMixin,
+    NextOrSuccessUrlMixin,
+    BSModalUpdateView,
 ):
     permission_required = ()
     template_name = "modal_form.html"

--- a/utils/tests/testcases.py
+++ b/utils/tests/testcases.py
@@ -194,6 +194,10 @@ class AbstractTestCases:
                 )
                 cls.user_with_add_perm.user_permissions.add(add_perm)
 
+                change_perm_codename = f"change_{cls.model._meta.model_name}"
+                change_perm = Permission.objects.get(codename=change_perm_codename)
+                cls.owner_user.user_permissions.add(change_perm)
+
             if cls.allow_create_for_any_authenticated_user:
                 cls.owner_user.user_permissions.add(add_perm)
                 cls.non_owner_user.user_permissions.add(add_perm)


### PR DESCRIPTION
Fixes four view-level access control gaps: #206, #209, #214, #217.

## Changes

**#209 — Update views missing change-permission enforcement** (centralized approach)
Instead of adding `PermissionRequiredMixin` and per-view `permission_required` strings, the model-level change permission is enforced centrally in the object policy layer:
- `get_object_policy()` now computes `has_change_permission` (`<app_label>.change_<model_name>`, staff always pass) and requires it for `can_edit`:
  ```
  can_edit = has_update_url and not is_archived and (is_staff or (is_owner and not is_published and has_change_permission))
  ```
- `UserCreatedObjectWriteAccessMixin` gains `object_policy_action = "edit"`; `UserCreatedObjectModalDeleteView` sets it to `"delete"` so delete views keep using `can_delete` (delete semantics unchanged, no change perm required to delete).
- No changes needed on `CollectorUpdateView`, `CollectionSystemUpdateView`, `WasteCategoryUpdateView`, `GreenhouseUpdateView` or their modal variants — they inherit the centralized check, aligning with the planned viewset consolidation.

**#206 — `SampleAddPropertyView` missing sample-level policy check**
Non-modal view now performs the same `get_object_policy` check on the parent sample as the modal version.

**#214 — `SelectNewlyCreatedObjectModelSelectOptionsView` uses global `max(created_at)`**
`get_selected_object()` now filters by `owner=self.request.user` before taking the latest, preventing selection of another user's object.

**#217 — `CollectionAddPropertyValueView` dispatch-order flaw**
Replaced the post-dispatch policy check (which ran after side effects) with a `UserPassesTestMixin.test_func` that validates the parent collection and `can_add_property` before dispatch.

## Behavioral note
Owners of unpublished user-created objects now additionally need the model's `change_*` permission to edit them (staff unaffected). Test bases and affected tests were updated to grant this permission.

## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Verification

- [x] Focused tests or checks were run — full suite: 5860 tests, only pre-existing `GeoJSONCachingTests` failures remain (unrelated cache backend issue, also failing on main).
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed (no JS/CSS changes).
- [x] No secrets, raw data, or production-only configuration are included.

Link to Devin session: https://app.devin.ai/sessions/bd65f3c75100483a8be8bed7d3ec02a6
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->