### PR TITLE
test: run GeoJSON caching tests against a real Redis cache

### DIFF
--- a/maps/tests/test_views.py
+++ b/maps/tests/test_views.py
@@ -1,18 +1,19 @@
 import io
 import json
+import os
 import re
 import uuid
 from datetime import date
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse, urlunparse
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, User
 from django.contrib.gis.geos import MultiPolygon, Point, Polygon
 from django.core.cache import caches
 from django.core.management import call_command
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from rest_framework import serializers
 from rest_framework.request import Request
@@ -1643,7 +1644,28 @@ class GeoJSONMixinTestCase(TestCase):
             self.viewset.geojson(request)
 
 
+def _redis_geojson_test_caches():
+    parsed = urlparse(os.environ.get("REDIS_URL", "redis://localhost:6379/0"))
+    location = urlunparse(parsed._replace(path="/14", query=""))
+    options = {
+        "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        "KEY_PREFIX": "geojson",
+    }
+    if parsed.scheme == "rediss":
+        options["CONNECTION_POOL_KWARGS"] = {"ssl_cert_reqs": None}
+    return {
+        "default": settings.CACHES["default"],
+        "geojson": {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": location,
+            "TIMEOUT": 86400,
+            "OPTIONS": options,
+        },
+    }
+
+
 @serial_test
+@override_settings(CACHES=_redis_geojson_test_caches())
 class GeoJSONCachingTests(TestCase):
     @classmethod
     def setUpTestData(cls):
@@ -1653,6 +1675,10 @@ class GeoJSONCachingTests(TestCase):
 
     def setUp(self):
         self.geojson_cache = caches[settings.GEOJSON_CACHE]
+        try:
+            self.geojson_cache.client.get_client(write=True).ping()
+        except Exception:
+            self.skipTest("Redis is not available for the geojson test cache.")
         self.geojson_cache.clear()
 
     def tearDown(self):


### PR DESCRIPTION
Fixes the CI failure:

```
AssertionError: monitor_cache command failed: Error accessing Redis client for cache 'geojson': Cannot automatically retrieve Redis client from cache backend 'geojson'. ...
```

`brit.settings.testrunner` switched the `geojson` cache to `LocMemCache`, which broke `GeoJSONCachingTests`: `monitor_cache` cannot obtain a Redis client, and pattern-based invalidation (`delete_pattern`) does not exist on LocMem, so `test_cache_invalidation_on_delete` and `test_clear_cache_command` failed too.

This PR class-scopes a real django-redis cache for these tests via `@override_settings(CACHES=_redis_geojson_test_caches())`, pointing the `geojson` alias at `REDIS_URL` (Redis DB 14, separate from the Celery test DB 15) and preserving the original scheme (adds `ssl_cert_reqs: None` for `rediss://`, as used by the local TLS-only Redis container). `setUp` skips the class gracefully if Redis is unreachable.

## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Verification

- [x] Focused tests or checks were run: `maps.tests.test_views.GeoJSONCachingTests` (5/5 pass) and full `maps.tests.test_views` (523 tests, OK) in the isolated worktree; ruff check/format clean.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed (no JS/CSS changes).
- [x] No secrets, raw data, or production-only configuration are included.

Link to Devin session: https://app.devin.ai/sessions/502f9250d9c742b1811f96f20c543afe
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->