### PR TITLE
fix(waste_atlas): add publication scoping + staff bypass to all Collection queries (#163)

### DIFF
--- a/sources/waste_collection/tests/test_views.py
+++ b/sources/waste_collection/tests/test_views.py
@@ -4561,6 +4561,7 @@ class WasteAtlasMapViewsTestCase(TestCase):
             collector=collector,
             catchment=collection_catchment,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
 
         response = self.client.get(

--- a/sources/waste_collection/tests/test_viewsets.py
+++ b/sources/waste_collection/tests/test_viewsets.py
@@ -4560,10 +4560,7 @@ class WasteAtlasPublicationScopingTests(APITestCase):
 
     def _catchment_ids(self, response):
         if isinstance(response.data, dict) and "features" in response.data:
-            return {
-                f["properties"]["catchment_id"]
-                for f in response.data["features"]
-            }
+            return {f["properties"]["catchment_id"] for f in response.data["features"]}
         return {row["catchment_id"] for row in response.data}
 
     def test_collection_system_excludes_private(self):

--- a/sources/waste_collection/tests/test_viewsets.py
+++ b/sources/waste_collection/tests/test_viewsets.py
@@ -2124,6 +2124,7 @@ class GreenWasteCollectionSystemCountViewSetTests(APITestCase):
             waste_category=waste_category,
             collection_system=collection_system,
             valid_from=date(year, 1, 1),
+            publication_status="published",
         )
 
     def test_returns_distinct_green_waste_system_count_per_catchment(self):
@@ -2218,6 +2219,7 @@ class CollectionConflictViewSetTests(APITestCase):
             waste_category=waste_category,
             collection_system=collection_system,
             valid_from=date(year, 1, 1),
+            publication_status="published",
         )
 
     def _conflict_ids(self, **params):
@@ -2249,6 +2251,7 @@ class CollectionConflictViewSetTests(APITestCase):
             waste_category=self.bio_category,
             collection_system=None,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
 
         conflicts = self._conflict_ids()
@@ -2432,6 +2435,7 @@ class CataloniaCollectionSystemViewSetTests(APITestCase):
             valid_from=date(2024, 1, 1),
             access_control_bp=access_control_bp,
             access_control_pap=access_control_pap,
+            publication_status="published",
         )
 
     def test_stream_specific_collection_system_endpoints(self):
@@ -2579,6 +2583,7 @@ class CollectionPointCountViewSetTests(APITestCase):
             waste_category=cls.waste_category,
             collection_system=collection_system,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
 
     def test_returns_primary_collection_point_count_per_catchment(self):
@@ -2625,6 +2630,7 @@ class ConnectionRateViewSetTests(APITestCase):
             waste_category=cls.bio_category,
             collection_system=cls.d2d,
             valid_from=date(2020, 1, 1),
+            publication_status="published",
         )
         cls.current_collection = Collection.objects.create(
             name="Current connection rate collection",
@@ -2633,6 +2639,7 @@ class ConnectionRateViewSetTests(APITestCase):
             collection_system=cls.d2d,
             valid_from=date(2024, 1, 1),
             participation_policy="MANDATORY",
+            publication_status="published",
         )
         cls.current_collection.predecessors.add(cls.previous_collection)
         CollectionPropertyValue.objects.create(
@@ -2722,6 +2729,7 @@ class WasteAtlasPrimarySelectionTests(APITestCase):
                 waste_category=cls.bio_category,
                 collection_system=cls.d2d,
                 valid_from=date(2024, 1, 1),
+                publication_status="published",
             )
             d2d_collection.allowed_materials.add(cls.paper_bags)
             CollectionPropertyValue.objects.create(
@@ -2737,6 +2745,7 @@ class WasteAtlasPrimarySelectionTests(APITestCase):
                 waste_category=cls.food_category,
                 collection_system=cls.bring_point,
                 valid_from=date(2024, 1, 1),
+                publication_status="published",
             )
 
         cls.no_collection_catchment = CollectionCatchment.objects.create(
@@ -2749,6 +2758,7 @@ class WasteAtlasPrimarySelectionTests(APITestCase):
             waste_category=cls.bio_category,
             collection_system=cls.no_collection,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
 
     def test_primary_selection_is_consistent_across_map_endpoints(self):
@@ -2915,6 +2925,7 @@ class BinConfigurationViewSetTests(APITestCase):
             collection_system=collection_system,
             bin_configuration=bin_configuration,
             valid_from=date(year, 1, 1),
+            publication_status="published",
         )
 
     def test_returns_bin_configuration_with_expected_fallbacks(self):
@@ -2990,6 +3001,7 @@ class NutsPrefixAtlasFilteringTests(APITestCase):
                 waste_category=cls.biowaste_category,
                 collection_system=cls.d2d,
                 valid_from=date(2022, 1, 1),
+                publication_status="published",
             )
 
         Collection.objects.create(
@@ -2999,6 +3011,7 @@ class NutsPrefixAtlasFilteringTests(APITestCase):
             collection_system=cls.d2d,
             frequency=cls.residual_frequency,
             valid_from=date(2022, 1, 1),
+            publication_status="published",
         )
 
     def test_collection_system_endpoint_respects_nuts_prefix(self):
@@ -3225,6 +3238,7 @@ class GreenWasteCollectionAmountViewSetTests(APITestCase):
             waste_category=waste_category,
             collection_system=collection_system,
             valid_from=date(year, 1, 1),
+            publication_status="published",
         )
 
     @classmethod
@@ -3315,6 +3329,7 @@ class BinSizeViewSetTests(APITestCase):
             min_bin_size=80,
             required_bin_capacity=10,
             required_bin_capacity_reference="person",
+            publication_status="published",
         )
         cls.residual_col = Collection.objects.create(
             name="BinSize residual col",
@@ -3325,6 +3340,7 @@ class BinSizeViewSetTests(APITestCase):
             min_bin_size=120,
             required_bin_capacity=40,
             required_bin_capacity_reference="household",
+            publication_status="published",
         )
         Collection.objects.create(
             name="BinSize no bin col",
@@ -3332,6 +3348,7 @@ class BinSizeViewSetTests(APITestCase):
             waste_category=cls.bio_category,
             collection_system=cls.d2d,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
         Collection.objects.create(
             name="BinSize bring point col",
@@ -3340,6 +3357,7 @@ class BinSizeViewSetTests(APITestCase):
             collection_system=cls.bring_point,
             valid_from=date(2024, 1, 1),
             min_bin_size=60,
+            publication_status="published",
         )
 
     def test_biowaste_min_bin_size_returns_d2d_collections(self):
@@ -3462,6 +3480,7 @@ class AtlasRatioViewSetTests(APITestCase):
             frequency=cls.bio_frequency,
             valid_from=date(2024, 1, 1),
             min_bin_size=60,
+            publication_status="published",
         )
         Collection.objects.create(
             name="Ratio residual collection",
@@ -3471,6 +3490,7 @@ class AtlasRatioViewSetTests(APITestCase):
             frequency=cls.residual_frequency,
             valid_from=date(2024, 1, 1),
             min_bin_size=120,
+            publication_status="published",
         )
         Collection.objects.create(
             name="Ratio residual only collection",
@@ -3480,6 +3500,7 @@ class AtlasRatioViewSetTests(APITestCase):
             frequency=cls.residual_frequency,
             valid_from=date(2024, 1, 1),
             min_bin_size=80,
+            publication_status="published",
         )
 
     @classmethod
@@ -3612,6 +3633,7 @@ class OrganicAmountViewSetTests(APITestCase):
             waste_category=cls.bio_category,
             collection_system=cls.d2d,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
         CollectionPropertyValue.objects.create(
             collection=bio_col_both,
@@ -3627,6 +3649,7 @@ class OrganicAmountViewSetTests(APITestCase):
             waste_category=cls.green_category,
             collection_system=cls.d2d,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
         acpv = AggregatedCollectionPropertyValue.objects.create(
             name="Organic green ACPV both",
@@ -3644,6 +3667,7 @@ class OrganicAmountViewSetTests(APITestCase):
             waste_category=cls.residual_category,
             collection_system=cls.d2d,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
         CollectionPropertyValue.objects.create(
             collection=residual_col_both,
@@ -3659,6 +3683,7 @@ class OrganicAmountViewSetTests(APITestCase):
             waste_category=cls.bio_category,
             collection_system=cls.d2d,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
         CollectionPropertyValue.objects.create(
             collection=bio_col_bio_only,
@@ -3674,6 +3699,7 @@ class OrganicAmountViewSetTests(APITestCase):
             waste_category=cls.green_category,
             collection_system=cls.d2d,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
         CollectionPropertyValue.objects.create(
             collection=green_col_green_only,
@@ -3689,6 +3715,7 @@ class OrganicAmountViewSetTests(APITestCase):
             waste_category=cls.residual_category,
             collection_system=cls.d2d,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
         CollectionPropertyValue.objects.create(
             collection=residual_col_only,
@@ -3810,6 +3837,7 @@ class SouthTyrolCollectionPointTests(APITestCase):
             waste_category=cls.bio_category,
             collection_system=cls.d2d,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
         cls.residual_collection = Collection.objects.create(
             name="South Tyrol Residual Collection",
@@ -3817,6 +3845,7 @@ class SouthTyrolCollectionPointTests(APITestCase):
             waste_category=cls.residual_category,
             collection_system=cls.d2d,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
         # Create collection point values
         CollectionPropertyValue.objects.create(
@@ -3841,6 +3870,7 @@ class SouthTyrolCollectionPointTests(APITestCase):
             waste_category=cls.bio_category,
             collection_system=cls.d2d,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
         CollectionPropertyValue.objects.create(
             collection=cls.bio_only_collection,
@@ -3906,6 +3936,7 @@ class SouthTyrolCollectionPointTests(APITestCase):
             waste_category=self.residual_category,
             collection_system=self.d2d,
             valid_from=date(2025, 1, 1),
+            publication_status="published",
         )
         CollectionPropertyValue.objects.create(
             collection=zero_collection,
@@ -3962,6 +3993,7 @@ class FalsyZeroRatioGuardTests(APITestCase):
             frequency=cls.bio_frequency,
             valid_from=date(2024, 1, 1),
             min_bin_size=60,
+            publication_status="published",
         )
         Collection.objects.create(
             name="Zero residual collection",
@@ -3971,6 +4003,7 @@ class FalsyZeroRatioGuardTests(APITestCase):
             frequency=cls.residual_frequency,
             valid_from=date(2024, 1, 1),
             min_bin_size=0,
+            publication_status="published",
         )
 
     @classmethod
@@ -4074,6 +4107,7 @@ class CollectionPointCountNoDataAndDtDTests(APITestCase):
             waste_category=cls.bio_category,
             collection_system=cls.d2d,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
 
         # Catchment B: biowaste bring-point collection, no CPV → no-data + is_door_to_door=False
@@ -4086,6 +4120,7 @@ class CollectionPointCountNoDataAndDtDTests(APITestCase):
             waste_category=cls.bio_category,
             collection_system=cls.bring_point,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
 
         # Catchment C: biowaste DtD (no CPV) + residual with CPV
@@ -4108,6 +4143,7 @@ class CollectionPointCountNoDataAndDtDTests(APITestCase):
             waste_category=cls.bio_category,
             collection_system=cls.d2d,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
         cls.residual_collection_c = Collection.objects.create(
             name="CP Residual Collection C",
@@ -4115,6 +4151,7 @@ class CollectionPointCountNoDataAndDtDTests(APITestCase):
             waste_category=cls.residual_category,
             collection_system=cls.bring_point,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
         # Only create a CPV for the property used by COLLECTION_POINT_COUNT_PROPERTY_NAME
         # (viewsets hardcode "number of collection points")
@@ -4212,6 +4249,7 @@ class BiowasteImpurityViewSetTests(APITestCase):
             waste_category=cls.bio_category,
             collection_system=cls.d2d,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
         CollectionPropertyValue.objects.create(
             collection=cls.collection_with_data,
@@ -4238,6 +4276,7 @@ class BiowasteImpurityViewSetTests(APITestCase):
             waste_category=cls.bio_category,
             collection_system=cls.d2d,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
 
         # Catchment C: No separate collection → no_collection=True
@@ -4250,6 +4289,7 @@ class BiowasteImpurityViewSetTests(APITestCase):
             waste_category=cls.bio_category,
             collection_system=cls.no_collection,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
 
     def _by_catchment(self, country="ES", year=2024):
@@ -4335,6 +4375,7 @@ class WeeklyBpAccessDaysViewSetTests(APITestCase):
             waste_category=cls.bio_category,
             collection_system=cls.bring_point,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
         CollectionPropertyValue.objects.create(
             collection=cls.collection_bp,
@@ -4354,6 +4395,7 @@ class WeeklyBpAccessDaysViewSetTests(APITestCase):
             waste_category=cls.bio_category,
             collection_system=cls.mixed,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
         CollectionPropertyValue.objects.create(
             collection=cls.collection_mixed,
@@ -4373,6 +4415,7 @@ class WeeklyBpAccessDaysViewSetTests(APITestCase):
             waste_category=cls.bio_category,
             collection_system=cls.d2d,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
 
         # Catchment D: bring-point but no CPV → has_bring_point=True, value null
@@ -4385,6 +4428,7 @@ class WeeklyBpAccessDaysViewSetTests(APITestCase):
             waste_category=cls.bio_category,
             collection_system=cls.bring_point,
             valid_from=date(2024, 1, 1),
+            publication_status="published",
         )
 
     def _by_catchment(self, country="ES", year=2024):
@@ -4430,3 +4474,144 @@ class WeeklyBpAccessDaysViewSetTests(APITestCase):
         self.assertIn("catchment_id", row)
         self.assertIn("weekly_access_days", row)
         self.assertIn("has_bring_point", row)
+
+
+class WasteAtlasPublicationScopingTests(APITestCase):
+    """Non-published collections must never appear in waste atlas API responses."""
+
+    ENDPOINTS = {
+        "collection_system": "/waste_collection/api/waste-atlas/collection-system/",
+        "catchment_geojson": "/waste_collection/api/waste-atlas/catchment/geojson/",
+        "collector_orga_level": "/waste_collection/api/waste-atlas/collector-orga-level/",
+        "collection_orga_level": "/waste_collection/api/waste-atlas/collection-orga-level/",
+        "connection_type": "/waste_collection/api/waste-atlas/connection-type/",
+        "conflicts": "/waste_collection/api/waste-atlas/collection-conflicts/",
+    }
+
+    @classmethod
+    def _region_with_borders(cls, name):
+        borders = GeoPolygon.objects.create(
+            geom="MULTIPOLYGON(((0 0, 0 1, 1 1, 1 0, 0 0)))",
+        )
+        return Region.objects.create(name=name, country="DE", borders=borders)
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.region = cls._region_with_borders("Pub Scope Region")
+        cls.d2d = CollectionSystem.objects.create(name="Door to door")
+        cls.bio_category = WasteCategory.objects.create(name="Biowaste")
+        cls.collector = Collector.objects.create(name="Pub Scope Collector")
+        cls.user = User.objects.create_user(username="pubscopeuser")
+
+        cls.published_catchment = CollectionCatchment.objects.create(
+            name="Published Catchment",
+            region=cls.region,
+        )
+        cls.collector.catchment = cls.published_catchment
+        cls.collector.save()
+
+        cls.published_collection = Collection.objects.create(
+            name="Published Collection",
+            owner=cls.user,
+            catchment=cls.published_catchment,
+            waste_category=cls.bio_category,
+            collection_system=cls.d2d,
+            valid_from=date(2024, 1, 1),
+            publication_status="published",
+            collector=cls.collector,
+        )
+
+        cls.private_catchment = CollectionCatchment.objects.create(
+            name="Private Catchment",
+            region=cls._region_with_borders("Private Region"),
+        )
+        cls.private_collector = Collector.objects.create(
+            name="Private Collector",
+            catchment=cls.private_catchment,
+        )
+        cls.private_collection = Collection.objects.create(
+            name="Private Collection",
+            owner=cls.user,
+            catchment=cls.private_catchment,
+            waste_category=cls.bio_category,
+            collection_system=cls.d2d,
+            valid_from=date(2024, 1, 1),
+            publication_status="private",
+            collector=cls.private_collector,
+        )
+
+        cls.review_catchment = CollectionCatchment.objects.create(
+            name="Review Catchment",
+            region=cls._region_with_borders("Review Region"),
+        )
+        cls.review_collection = Collection.objects.create(
+            name="Review Collection",
+            owner=cls.user,
+            catchment=cls.review_catchment,
+            waste_category=cls.bio_category,
+            collection_system=cls.d2d,
+            valid_from=date(2024, 1, 1),
+            publication_status="review",
+        )
+
+    def _get(self, endpoint_key, **extra_params):
+        params = {"country": "DE", "year": 2024, **extra_params}
+        return self.client.get(self.ENDPOINTS[endpoint_key], params)
+
+    def _catchment_ids(self, response):
+        if isinstance(response.data, dict) and "features" in response.data:
+            return {
+                f["properties"]["catchment_id"]
+                for f in response.data["features"]
+            }
+        return {row["catchment_id"] for row in response.data}
+
+    def test_collection_system_excludes_private(self):
+        response = self._get("collection_system")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = self._catchment_ids(response)
+        self.assertIn(self.published_catchment.id, ids)
+        self.assertNotIn(self.private_catchment.id, ids)
+
+    def test_collection_system_excludes_review(self):
+        response = self._get("collection_system")
+        ids = self._catchment_ids(response)
+        self.assertNotIn(self.review_catchment.id, ids)
+
+    def test_catchment_geojson_excludes_non_published(self):
+        response = self._get("catchment_geojson")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = self._catchment_ids(response)
+        self.assertIn(self.published_catchment.id, ids)
+        self.assertNotIn(self.private_catchment.id, ids)
+        self.assertNotIn(self.review_catchment.id, ids)
+
+    def test_collector_orga_level_excludes_non_published(self):
+        response = self._get("collector_orga_level")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = self._catchment_ids(response)
+        self.assertIn(self.published_catchment.id, ids)
+        self.assertNotIn(self.private_catchment.id, ids)
+
+    def test_collection_orga_level_excludes_non_published(self):
+        response = self._get("collection_orga_level")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = self._catchment_ids(response)
+        self.assertIn(self.published_catchment.id, ids)
+        self.assertNotIn(self.private_catchment.id, ids)
+        self.assertNotIn(self.review_catchment.id, ids)
+
+    def test_connection_type_excludes_non_published(self):
+        response = self._get("connection_type")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = self._catchment_ids(response)
+        self.assertIn(self.published_catchment.id, ids)
+        self.assertNotIn(self.private_catchment.id, ids)
+        self.assertNotIn(self.review_catchment.id, ids)
+
+    def test_conflicts_excludes_non_published(self):
+        response = self._get("conflicts", theme="collection_system")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = self._catchment_ids(response)
+        self.assertNotIn(self.private_catchment.id, ids)
+        self.assertNotIn(self.review_catchment.id, ids)

--- a/sources/waste_collection/tests/test_viewsets.py
+++ b/sources/waste_collection/tests/test_viewsets.py
@@ -4484,7 +4484,7 @@ class WasteAtlasPublicationScopingTests(APITestCase):
         "catchment_geojson": "/waste_collection/api/waste-atlas/catchment/geojson/",
         "collector_orga_level": "/waste_collection/api/waste-atlas/collector-orga-level/",
         "collection_orga_level": "/waste_collection/api/waste-atlas/collection-orga-level/",
-        "connection_type": "/waste_collection/api/waste-atlas/connection-type/",
+        "participation_policy": "/waste_collection/api/waste-atlas/participation-policy/",
         "conflicts": "/waste_collection/api/waste-atlas/collection-conflicts/",
     }
 
@@ -4598,8 +4598,8 @@ class WasteAtlasPublicationScopingTests(APITestCase):
         self.assertNotIn(self.private_catchment.id, ids)
         self.assertNotIn(self.review_catchment.id, ids)
 
-    def test_connection_type_excludes_non_published(self):
-        response = self._get("connection_type")
+    def test_participation_policy_excludes_non_published(self):
+        response = self._get("participation_policy")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         ids = self._catchment_ids(response)
         self.assertIn(self.published_catchment.id, ids)
@@ -4610,5 +4610,47 @@ class WasteAtlasPublicationScopingTests(APITestCase):
         response = self._get("conflicts", theme="collection_system")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         ids = self._catchment_ids(response)
+        self.assertNotIn(self.private_catchment.id, ids)
+        self.assertNotIn(self.review_catchment.id, ids)
+
+    # --- Staff bypass tests ---
+
+    def test_staff_sees_private_and_review_in_collection_system(self):
+        staff = User.objects.create_user("staffuser", is_staff=True)
+        self.client.force_login(staff)
+        response = self._get("collection_system")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = self._catchment_ids(response)
+        self.assertIn(self.published_catchment.id, ids)
+        self.assertIn(self.private_catchment.id, ids)
+        self.assertIn(self.review_catchment.id, ids)
+
+    def test_staff_sees_private_and_review_in_catchment_geojson(self):
+        staff = User.objects.create_user("staffuser2", is_staff=True)
+        self.client.force_login(staff)
+        response = self._get("catchment_geojson")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = self._catchment_ids(response)
+        self.assertIn(self.published_catchment.id, ids)
+        self.assertIn(self.private_catchment.id, ids)
+        self.assertIn(self.review_catchment.id, ids)
+
+    def test_staff_sees_private_and_review_in_collection_orga_level(self):
+        staff = User.objects.create_user("staffuser3", is_staff=True)
+        self.client.force_login(staff)
+        response = self._get("collection_orga_level")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = self._catchment_ids(response)
+        self.assertIn(self.published_catchment.id, ids)
+        self.assertIn(self.private_catchment.id, ids)
+        self.assertIn(self.review_catchment.id, ids)
+
+    def test_anonymous_still_excluded_after_staff_bypass(self):
+        """Ensure anonymous users still only see published after staff bypass."""
+        self.client.logout()
+        response = self._get("collection_system")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = self._catchment_ids(response)
+        self.assertIn(self.published_catchment.id, ids)
         self.assertNotIn(self.private_catchment.id, ids)
         self.assertNotIn(self.review_catchment.id, ids)

--- a/sources/waste_collection/tests/test_waste_atlas_biowaste_amount.py
+++ b/sources/waste_collection/tests/test_waste_atlas_biowaste_amount.py
@@ -189,6 +189,7 @@ class BiowasteCollectionAmountViewSetTests(APITestCase):
             waste_category=cls.biowaste,
             collection_system=collection_system,
             valid_from=date(year, 1, 1),
+            publication_status="published",
         )
 
     @classmethod

--- a/sources/waste_collection/waste_atlas/viewsets.py
+++ b/sources/waste_collection/waste_atlas/viewsets.py
@@ -72,6 +72,39 @@ from .serializers import (
 )
 
 _PUBLISHED = UserCreatedObject.STATUS_PUBLISHED
+_STAFF_VISIBLE = (
+    UserCreatedObject.STATUS_PUBLISHED,
+    UserCreatedObject.STATUS_REVIEW,
+    UserCreatedObject.STATUS_PRIVATE,
+)
+
+
+def _is_staff(user):
+    return user is not None and hasattr(user, "is_staff") and user.is_staff
+
+
+def _collection_qs(user=None):
+    """Base Collection queryset respecting publication scoping.
+
+    Staff users see published, review, and private collections so they can
+    monitor data-collection progress.  Everyone else sees only published.
+    """
+    if _is_staff(user):
+        return Collection.objects.filter(publication_status__in=_STAFF_VISIBLE)
+    return Collection.objects.published()
+
+
+def _publication_q(user=None, prefix=""):
+    """Return a Q filter for publication_status on a related collection path.
+
+    *prefix* is the ORM lookup prefix ending with ``__`` when non-empty,
+    e.g. ``"collections__"`` for reverse-FK through catchments.
+    """
+    field = f"{prefix}publication_status"
+    if _is_staff(user):
+        return Q(**{f"{field}__in": _STAFF_VISIBLE})
+    return Q(**{field: _PUBLISHED})
+
 
 # Material IDs for food waste classification (Karte 4)
 _FOOD_WASTE_MATERIAL_IDS = {11, 12, 13, 14}
@@ -279,8 +312,9 @@ def _select_primary_collections(
     *,
     extra_fields=(),
     extra_filters=None,
+    user=None,
 ):
-    qs = Collection.objects.published().filter(
+    qs = _collection_qs(user).filter(
         _country_filter_q("catchment__", country),
         valid_from__year=year,
     )
@@ -420,14 +454,13 @@ def _catchment_orga_level_case(catchment_path="catchment__"):
     )
 
 
-def _active_collector_scope(country, year, nuts_prefixes):
+def _active_collector_scope(country, year, nuts_prefixes, user=None):
     """Return collectors with collection records in the selected atlas year."""
     qs = Collector.objects.filter(
         _country_filter_q("catchment__", country),
         catchment__isnull=False,
         collection__valid_from__year=year,
-        collection__publication_status=_PUBLISHED,
-    )
+    ).filter(_publication_q(user, prefix="collection__"))
     return _apply_nuts_prefix_filter(qs, nuts_prefixes, catchment_path="catchment__")
 
 
@@ -451,13 +484,14 @@ class CatchmentViewSet(WasteAtlasReadOnlyModelViewSet):
         """Return distinct catchments matching the country/year filter."""
         country, year = _parse_country_year(self.request)
         nuts_prefixes = _parse_nuts_prefixes(self.request)
+        user = self.request.user
         qs = (
             CollectionCatchment.objects.filter(
                 _country_filter_q("", country),
                 collections__valid_from__year=year,
-                collections__publication_status=_PUBLISHED,
                 region__borders__isnull=False,
             )
+            .filter(_publication_q(user, prefix="collections__"))
             .distinct()
             .select_related("region", "region__borders")
         )
@@ -500,9 +534,9 @@ class CatchmentViewSet(WasteAtlasReadOnlyModelViewSet):
         """Return GeoJSON for catchments assigned directly to collectors."""
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
-        collector_scope = _active_collector_scope(country, year, nuts_prefixes).filter(
-            catchment__region__borders__isnull=False
-        )
+        collector_scope = _active_collector_scope(
+            country, year, nuts_prefixes, user=request.user
+        ).filter(catchment__region__borders__isnull=False)
         queryset = (
             CollectionCatchment.objects.filter(
                 id__in=collector_scope.values("catchment_id")
@@ -554,7 +588,7 @@ class OrgaLevelViewSet(WasteAtlasViewSet):
         nuts_prefixes = _parse_nuts_prefixes(request)
 
         qs = (
-            _active_collector_scope(country, year, nuts_prefixes)
+            _active_collector_scope(country, year, nuts_prefixes, user=request.user)
             .distinct()
             .annotate(orga_level=_catchment_orga_level_case())
             .values("catchment_id", "orga_level")
@@ -583,7 +617,7 @@ class CollectionOrgaLevelViewSet(WasteAtlasViewSet):
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
 
-        qs = Collection.objects.published().filter(
+        qs = _collection_qs(request.user).filter(
             _country_filter_q("catchment__", country),
             catchment__isnull=False,
             valid_from__year=year,
@@ -634,6 +668,7 @@ class CollectionSystemViewSet(WasteAtlasViewSet):
                 year,
                 ["Biowaste", "Food waste"],
                 nuts_prefixes,
+                user=request.user,
             ).items()
         ]
         serializer = CatchmentCollectionSystemSerializer(data, many=True)
@@ -653,6 +688,7 @@ class BiowasteCollectionSystemViewSet(WasteAtlasViewSet):
                 year,
                 ["Biowaste", "Food waste"],
                 nuts_prefixes,
+                user=request.user,
             ).items()
         ]
         serializer = CatchmentCollectionSystemSerializer(data, many=True)
@@ -672,6 +708,7 @@ class ResidualCollectionSystemViewSet(WasteAtlasViewSet):
                 year,
                 ["Residual waste"],
                 nuts_prefixes,
+                user=request.user,
             ).items()
         ]
         serializer = CatchmentCollectionSystemSerializer(data, many=True)
@@ -689,12 +726,14 @@ class CombinedCollectionSystemViewSet(WasteAtlasViewSet):
             year,
             ["Biowaste", "Food waste"],
             nuts_prefixes,
+            user=request.user,
         )
         residual = _select_primary_collections(
             country,
             year,
             ["Residual waste"],
             nuts_prefixes,
+            user=request.user,
         )
         data = [
             {
@@ -722,6 +761,7 @@ class CataloniaSystemAccessControlViewSet(WasteAtlasViewSet):
             ["Biowaste", "Food waste"],
             nuts_prefixes,
             extra_fields=("access_control_bp", "access_control_pap"),
+            user=request.user,
         )
         residual = _select_primary_collections(
             country,
@@ -729,6 +769,7 @@ class CataloniaSystemAccessControlViewSet(WasteAtlasViewSet):
             ["Residual waste"],
             nuts_prefixes,
             extra_fields=("access_control_bp", "access_control_pap"),
+            user=request.user,
         )
         data = []
         for cid in set(bio) | set(residual):
@@ -768,6 +809,7 @@ class AccessControlViewSet(WasteAtlasViewSet):
             ["Biowaste", "Food waste"],
             nuts_prefixes,
             extra_fields=("access_control_bp", "access_control_pap"),
+            user=request.user,
         )
 
         data = []
@@ -821,6 +863,7 @@ class BinConfigurationViewSet(WasteAtlasViewSet):
             ["Biowaste", "Food waste"],
             nuts_prefixes,
             extra_fields=("bin_configuration__name",),
+            user=request.user,
         )
 
         data = []
@@ -857,7 +900,7 @@ class GreenWasteCollectionSystemCountViewSet(WasteAtlasViewSet):
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
         qs = _filter_by_waste_categories(
-            Collection.objects.published().filter(
+            _collection_qs(request.user).filter(
                 _country_filter_q("catchment__", country),
                 valid_from__year=year,
             ),
@@ -896,7 +939,7 @@ def _classify_food_waste(material_ids):
     return "Uncategorized"
 
 
-def _get_material_status(country, year, material_id, nuts_prefixes=()):
+def _get_material_status(country, year, material_id, nuts_prefixes=(), user=None):
     """Return per-catchment allowed/forbidden status for a given material.
 
     Returns a list of dicts: ``[{catchment_id, status}]`` where *status* is
@@ -908,6 +951,7 @@ def _get_material_status(country, year, material_id, nuts_prefixes=()):
         year,
         ["Biowaste", "Food waste"],
         nuts_prefixes,
+        user=user,
     )
 
     collection_ids = [
@@ -948,7 +992,12 @@ def _get_material_status(country, year, material_id, nuts_prefixes=()):
 
 
 def _get_collection_count(
-    country, year, waste_categories, nuts_prefixes=(), include_missing_primary=False
+    country,
+    year,
+    waste_categories,
+    nuts_prefixes=(),
+    include_missing_primary=False,
+    user=None,
 ):
     """Return per-catchment annual collection count for the given waste categories.
 
@@ -957,7 +1006,7 @@ def _get_collection_count(
     Non-door-to-door catchments are excluded (they have no frequency data).
     """
     qs = _filter_by_waste_categories(
-        Collection.objects.published().filter(
+        _collection_qs(user).filter(
             _country_filter_q("catchment__", country),
             valid_from__year=year,
             collection_system__name="Door to door",
@@ -995,6 +1044,7 @@ def _get_collection_count(
             year,
             waste_categories,
             nuts_prefixes,
+            user=user,
         )
         for cid, row in best_system.items():
             if cid not in existing_ids:
@@ -1009,7 +1059,7 @@ def _get_collection_count(
     return data
 
 
-def _get_frequency_type(country, year, waste_categories, nuts_prefixes=()):
+def _get_frequency_type(country, year, waste_categories, nuts_prefixes=(), user=None):
     """Return per-catchment frequency type for the given waste categories.
 
     For door-to-door collections, returns the ``CollectionFrequency.type``;
@@ -1021,6 +1071,7 @@ def _get_frequency_type(country, year, waste_categories, nuts_prefixes=()):
         waste_categories,
         nuts_prefixes,
         extra_fields=("frequency__type",),
+        user=user,
     )
 
     data = []
@@ -1049,7 +1100,9 @@ class ResidualFrequencyTypeViewSet(WasteAtlasViewSet):
         """Return a JSON array of {catchment_id, frequency_type}."""
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
-        data = _get_frequency_type(country, year, ["Residual waste"], nuts_prefixes)
+        data = _get_frequency_type(
+            country, year, ["Residual waste"], nuts_prefixes, user=request.user
+        )
         serializer = CatchmentFrequencyTypeSerializer(data, many=True)
         return Response(serializer.data)
 
@@ -1071,13 +1124,21 @@ class CombinedFrequencyTypeViewSet(WasteAtlasViewSet):
         bio = {
             r["catchment_id"]: r["frequency_type"]
             for r in _get_frequency_type(
-                country, year, ["Biowaste", "Food waste"], nuts_prefixes
+                country,
+                year,
+                ["Biowaste", "Food waste"],
+                nuts_prefixes,
+                user=request.user,
             )
         }
         res = {
             r["catchment_id"]: r["frequency_type"]
             for r in _get_frequency_type(
-                country, year, ["Residual waste"], nuts_prefixes
+                country,
+                year,
+                ["Residual waste"],
+                nuts_prefixes,
+                user=request.user,
             )
         }
         all_ids = set(bio) | set(res)
@@ -1109,7 +1170,11 @@ class BiowasteFrequencyTypeViewSet(WasteAtlasViewSet):
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
         data = _get_frequency_type(
-            country, year, ["Biowaste", "Food waste"], nuts_prefixes
+            country,
+            year,
+            ["Biowaste", "Food waste"],
+            nuts_prefixes,
+            user=request.user,
         )
         serializer = CatchmentFrequencyTypeSerializer(data, many=True)
         return Response(serializer.data)
@@ -1129,7 +1194,9 @@ class ResidualCollectionCountViewSet(WasteAtlasViewSet):
         """Return a JSON array of {catchment_id, collection_count, has_seasonal_variation}."""
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
-        data = _get_collection_count(country, year, ["Residual waste"], nuts_prefixes)
+        data = _get_collection_count(
+            country, year, ["Residual waste"], nuts_prefixes, user=request.user
+        )
         serializer = CatchmentCollectionCountSerializer(data, many=True)
         return Response(serializer.data)
 
@@ -1156,6 +1223,7 @@ class BiowasteCollectionCountViewSet(WasteAtlasViewSet):
             ["Biowaste", "Food waste"],
             nuts_prefixes,
             include_missing_primary=True,
+            user=request.user,
         )
         serializer = CatchmentCollectionCountSerializer(door_to_door, many=True)
         return Response(serializer.data)
@@ -1183,12 +1251,17 @@ class CombinedCollectionCountViewSet(WasteAtlasViewSet):
                 ["Biowaste", "Food waste"],
                 nuts_prefixes,
                 include_missing_primary=True,
+                user=request.user,
             )
         }
         res = {
             r["catchment_id"]: r
             for r in _get_collection_count(
-                country, year, ["Residual waste"], nuts_prefixes
+                country,
+                year,
+                ["Residual waste"],
+                nuts_prefixes,
+                user=request.user,
             )
         }
         all_ids = set(bio) | set(res)
@@ -1220,12 +1293,17 @@ class CollectionCountRatioViewSet(WasteAtlasViewSet):
                 ["Biowaste", "Food waste"],
                 nuts_prefixes,
                 include_missing_primary=True,
+                user=request.user,
             )
         }
         res = {
             r["catchment_id"]: r
             for r in _get_collection_count(
-                country, year, ["Residual waste"], nuts_prefixes
+                country,
+                year,
+                ["Residual waste"],
+                nuts_prefixes,
+                user=request.user,
             )
         }
         all_ids = set(bio) | set(res)
@@ -1263,12 +1341,13 @@ class CollectionPointCountViewSet(WasteAtlasViewSet):
     permission_classes = [permissions.AllowAny]
     waste_categories = None
 
-    def _get_data(self, country, year, nuts_prefixes):
+    def _get_data(self, country, year, nuts_prefixes, user=None):
         best = _select_primary_collections(
             country,
             year,
             self.waste_categories,
             nuts_prefixes,
+            user=user,
         )
 
         collection_ids = [row["collection_id"] for row in best.values()]
@@ -1297,7 +1376,7 @@ class CollectionPointCountViewSet(WasteAtlasViewSet):
     def list(self, request):
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
-        data = self._get_data(country, year, nuts_prefixes)
+        data = self._get_data(country, year, nuts_prefixes, user=request.user)
         serializer = CatchmentCollectionPointCountSerializer(data, many=True)
         return Response(serializer.data)
 
@@ -1319,13 +1398,13 @@ class CollectionPointCountRatioViewSet(WasteAtlasViewSet):
         bio = {
             r["catchment_id"]: r
             for r in BiowasteCollectionPointCountViewSet()._get_data(
-                country, year, nuts_prefixes
+                country, year, nuts_prefixes, user=request.user
             )
         }
         res = {
             r["catchment_id"]: r
             for r in ResidualCollectionPointCountViewSet()._get_data(
-                country, year, nuts_prefixes
+                country, year, nuts_prefixes, user=request.user
             )
         }
         all_ids = set(bio) | set(res)
@@ -1356,7 +1435,7 @@ class CollectionPointCountRatioViewSet(WasteAtlasViewSet):
         return Response(serializer.data)
 
 
-def _get_fee_system(country, year, waste_categories, nuts_prefixes=()):
+def _get_fee_system(country, year, waste_categories, nuts_prefixes=(), user=None):
     """Return per-catchment fee system for the given waste categories.
 
     For biowaste, non-door-to-door catchments return the collection
@@ -1368,6 +1447,7 @@ def _get_fee_system(country, year, waste_categories, nuts_prefixes=()):
         waste_categories,
         nuts_prefixes,
         extra_fields=("fee_system__name",),
+        user=user,
     )
 
     data = []
@@ -1398,7 +1478,9 @@ class ResidualFeeSystemViewSet(WasteAtlasViewSet):
         """Return a JSON array of {catchment_id, fee_system}."""
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
-        data = _get_fee_system(country, year, ["Residual waste"], nuts_prefixes)
+        data = _get_fee_system(
+            country, year, ["Residual waste"], nuts_prefixes, user=request.user
+        )
         serializer = CatchmentFeeSystemSerializer(data, many=True)
         return Response(serializer.data)
 
@@ -1417,7 +1499,13 @@ class BiowasteFeeSystemViewSet(WasteAtlasViewSet):
         """Return a JSON array of {catchment_id, fee_system}."""
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
-        data = _get_fee_system(country, year, ["Biowaste", "Food waste"], nuts_prefixes)
+        data = _get_fee_system(
+            country,
+            year,
+            ["Biowaste", "Food waste"],
+            nuts_prefixes,
+            user=request.user,
+        )
         serializer = CatchmentFeeSystemSerializer(data, many=True)
         return Response(serializer.data)
 
@@ -1439,12 +1527,22 @@ class CombinedFeeSystemViewSet(WasteAtlasViewSet):
         bio = {
             r["catchment_id"]: r["fee_system"]
             for r in _get_fee_system(
-                country, year, ["Biowaste", "Food waste"], nuts_prefixes
+                country,
+                year,
+                ["Biowaste", "Food waste"],
+                nuts_prefixes,
+                user=request.user,
             )
         }
         res = {
             r["catchment_id"]: r["fee_system"]
-            for r in _get_fee_system(country, year, ["Residual waste"], nuts_prefixes)
+            for r in _get_fee_system(
+                country,
+                year,
+                ["Residual waste"],
+                nuts_prefixes,
+                user=request.user,
+            )
         }
         all_ids = set(bio) | set(res)
         data = [
@@ -1466,6 +1564,7 @@ def _get_collection_amount(
     nuts_prefixes=(),
     include_value_source=False,
     include_acpv_group_key=False,
+    user=None,
 ):
     """Return per-catchment collection amount in kg/person/year.
 
@@ -1485,6 +1584,7 @@ def _get_collection_amount(
         year,
         waste_categories,
         nuts_prefixes,
+        user=user,
     )
 
     catchment_ids = list(best.keys())
@@ -1493,7 +1593,7 @@ def _get_collection_amount(
     # Step 2: map catchments → all collection IDs (any year)
     # ------------------------------------------------------------------
     all_col_rows = _filter_by_waste_categories(
-        Collection.objects.published().filter(
+        _collection_qs(user).filter(
             catchment_id__in=catchment_ids,
         ),
         waste_categories,
@@ -1686,7 +1786,7 @@ def _amounts_for_2024(year, all_collection_ids, col_to_cid, catchment_ids):
     return _amounts_for_year(year, all_collection_ids, col_to_cid, catchment_ids)
 
 
-def _get_biowaste_acpv_outline_geojson(country, year, nuts_prefixes=()):
+def _get_biowaste_acpv_outline_geojson(country, year, nuts_prefixes=(), user=None):
     amount_rows = _get_collection_amount(
         country,
         year,
@@ -1694,6 +1794,7 @@ def _get_biowaste_acpv_outline_geojson(country, year, nuts_prefixes=()):
         nuts_prefixes,
         include_value_source=True,
         include_acpv_group_key=True,
+        user=user,
     )
     catchment_ids_by_group: dict[str, list[int]] = {}
     for row in amount_rows:
@@ -1744,7 +1845,7 @@ def _get_biowaste_acpv_outline_geojson(country, year, nuts_prefixes=()):
     return _build_feature_collection(features)
 
 
-def _get_green_waste_collection_amount(country, year, nuts_prefixes=()):
+def _get_green_waste_collection_amount(country, year, nuts_prefixes=(), user=None):
     """Return per-catchment green-waste amount in kg/person/year.
 
     Priority for amount resolution:
@@ -1758,6 +1859,7 @@ def _get_green_waste_collection_amount(country, year, nuts_prefixes=()):
         year,
         _GREEN_WASTE_CATEGORY_NAMES,
         nuts_prefixes,
+        user=user,
     )
 
     scoped_catchment_ids = list(
@@ -1765,8 +1867,9 @@ def _get_green_waste_collection_amount(country, year, nuts_prefixes=()):
             CollectionCatchment.objects.filter(
                 _country_filter_q("", country),
                 collections__valid_from__year=year,
-                collections__publication_status=_PUBLISHED,
-            ).distinct(),
+            )
+            .filter(_publication_q(user, prefix="collections__"))
+            .distinct(),
             nuts_prefixes,
         ).values_list("id", flat=True)
     )
@@ -1784,7 +1887,7 @@ def _get_green_waste_collection_amount(country, year, nuts_prefixes=()):
         return []
 
     all_col_rows = _filter_by_waste_categories(
-        Collection.objects.published().filter(
+        _collection_qs(user).filter(
             catchment_id__in=catchment_ids,
         ),
         _GREEN_WASTE_CATEGORY_NAMES,
@@ -1953,7 +2056,9 @@ class ResidualCollectionAmountViewSet(WasteAtlasViewSet):
         """Return a JSON array of {catchment_id, amount}."""
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
-        data = _get_collection_amount(country, year, ["Residual waste"], nuts_prefixes)
+        data = _get_collection_amount(
+            country, year, ["Residual waste"], nuts_prefixes, user=request.user
+        )
         serializer = CatchmentCollectionAmountSerializer(data, many=True)
         return Response(serializer.data)
 
@@ -1979,6 +2084,7 @@ class BiowasteCollectionAmountViewSet(WasteAtlasViewSet):
             nuts_prefixes,
             include_value_source=True,
             include_acpv_group_key=True,
+            user=request.user,
         )
         serializer = CatchmentCollectionAmountSerializer(data, many=True)
         return Response(serializer.data)
@@ -1988,7 +2094,9 @@ class BiowasteCollectionAmountViewSet(WasteAtlasViewSet):
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
         return Response(
-            _get_biowaste_acpv_outline_geojson(country, year, nuts_prefixes)
+            _get_biowaste_acpv_outline_geojson(
+                country, year, nuts_prefixes, user=request.user
+            )
         )
 
 
@@ -2006,13 +2114,20 @@ class GreenWasteCollectionAmountViewSet(WasteAtlasViewSet):
         """Return a JSON array of {catchment_id, amount, no_collection}."""
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
-        data = _get_green_waste_collection_amount(country, year, nuts_prefixes)
+        data = _get_green_waste_collection_amount(
+            country, year, nuts_prefixes, user=request.user
+        )
         serializer = CatchmentCollectionAmountSerializer(data, many=True)
         return Response(serializer.data)
 
 
 def _get_min_bin_size(
-    country, year, waste_categories, nuts_prefixes=(), include_missing_primary=False
+    country,
+    year,
+    waste_categories,
+    nuts_prefixes=(),
+    include_missing_primary=False,
+    user=None,
 ):
     """Return per-catchment minimum bin size (L) for door-to-door collections.
 
@@ -2021,7 +2136,7 @@ def _get_min_bin_size(
     Only door-to-door collections carry meaningful bin size data.
     """
     qs = _filter_by_waste_categories(
-        Collection.objects.published().filter(
+        _collection_qs(user).filter(
             _country_filter_q("catchment__", country),
             valid_from__year=year,
             collection_system__name="Door to door",
@@ -2042,6 +2157,7 @@ def _get_min_bin_size(
             year,
             waste_categories,
             nuts_prefixes,
+            user=user,
         )
         for cid, row in best_system.items():
             if cid not in best:
@@ -2058,7 +2174,12 @@ def _get_min_bin_size(
 
 
 def _get_required_bin_capacity(
-    country, year, waste_categories, nuts_prefixes=(), include_missing_primary=False
+    country,
+    year,
+    waste_categories,
+    nuts_prefixes=(),
+    include_missing_primary=False,
+    user=None,
 ):
     """Return per-catchment required specific bin capacity for door-to-door collections.
 
@@ -2067,7 +2188,7 @@ def _get_required_bin_capacity(
     not_specified) for the primary door-to-door collection per catchment.
     """
     qs = _filter_by_waste_categories(
-        Collection.objects.published().filter(
+        _collection_qs(user).filter(
             _country_filter_q("catchment__", country),
             valid_from__year=year,
             collection_system__name="Door to door",
@@ -2090,6 +2211,7 @@ def _get_required_bin_capacity(
             year,
             waste_categories,
             nuts_prefixes,
+            user=user,
         )
         for cid, row in best_system.items():
             if cid not in best:
@@ -2126,6 +2248,7 @@ class BiowasteMinBinSizeViewSet(WasteAtlasViewSet):
             ["Biowaste", "Food waste"],
             nuts_prefixes,
             include_missing_primary=True,
+            user=request.user,
         )
         serializer = CatchmentMinBinSizeSerializer(data, many=True)
         return Response(serializer.data)
@@ -2145,7 +2268,9 @@ class ResidualMinBinSizeViewSet(WasteAtlasViewSet):
         """Return a JSON array of {catchment_id, min_bin_size}."""
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
-        data = _get_min_bin_size(country, year, ["Residual waste"], nuts_prefixes)
+        data = _get_min_bin_size(
+            country, year, ["Residual waste"], nuts_prefixes, user=request.user
+        )
         serializer = CatchmentMinBinSizeSerializer(data, many=True)
         return Response(serializer.data)
 
@@ -2164,11 +2289,18 @@ class MinBinSizeRatioViewSet(WasteAtlasViewSet):
                 ["Biowaste", "Food waste"],
                 nuts_prefixes,
                 include_missing_primary=True,
+                user=request.user,
             )
         }
         res = {
             r["catchment_id"]: r
-            for r in _get_min_bin_size(country, year, ["Residual waste"], nuts_prefixes)
+            for r in _get_min_bin_size(
+                country,
+                year,
+                ["Residual waste"],
+                nuts_prefixes,
+                user=request.user,
+            )
         }
         all_ids = set(bio) | set(res)
         data = []
@@ -2216,6 +2348,7 @@ class BiowasteRequiredBinCapacityViewSet(WasteAtlasViewSet):
             ["Biowaste", "Food waste"],
             nuts_prefixes,
             include_missing_primary=True,
+            user=request.user,
         )
         serializer = CatchmentRequiredBinCapacitySerializer(data, many=True)
         return Response(serializer.data)
@@ -2236,7 +2369,7 @@ class ResidualRequiredBinCapacityViewSet(WasteAtlasViewSet):
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
         data = _get_required_bin_capacity(
-            country, year, ["Residual waste"], nuts_prefixes
+            country, year, ["Residual waste"], nuts_prefixes, user=request.user
         )
         serializer = CatchmentRequiredBinCapacitySerializer(data, many=True)
         return Response(serializer.data)
@@ -2245,7 +2378,7 @@ class ResidualRequiredBinCapacityViewSet(WasteAtlasViewSet):
 _ORGANIC_CATEGORY_NAMES = ["Biowaste", "Food waste"] + _GREEN_WASTE_CATEGORY_NAMES
 
 
-def _get_organic_amounts(country, year, nuts_prefixes=()):
+def _get_organic_amounts(country, year, nuts_prefixes=(), user=None):
     """Return per-catchment summed organic waste amount (kg/person/year).
 
     Sums bio/food waste from ``_get_collection_amount`` with green waste from
@@ -2253,9 +2386,11 @@ def _get_organic_amounts(country, year, nuts_prefixes=()):
     source are included; amounts are summed where both are available.
     """
     bio_rows = _get_collection_amount(
-        country, year, ["Biowaste", "Food waste"], nuts_prefixes
+        country, year, ["Biowaste", "Food waste"], nuts_prefixes, user=user
     )
-    green_rows = _get_green_waste_collection_amount(country, year, nuts_prefixes)
+    green_rows = _get_green_waste_collection_amount(
+        country, year, nuts_prefixes, user=user
+    )
 
     bio_map = {
         r["catchment_id"]: r["amount"] for r in bio_rows if not r.get("no_collection")
@@ -2297,7 +2432,9 @@ class OrganicCollectionAmountViewSet(WasteAtlasViewSet):
         """Return a JSON array of {catchment_id, amount}."""
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
-        organic = _get_organic_amounts(country, year, nuts_prefixes)
+        organic = _get_organic_amounts(
+            country, year, nuts_prefixes, user=request.user
+        )
         data = [{"catchment_id": cid, "amount": amt} for cid, amt in organic.items()]
         serializer = CatchmentCollectionAmountSerializer(data, many=True)
         return Response(serializer.data)
@@ -2317,11 +2454,13 @@ class OrganicWasteRatioViewSet(WasteAtlasViewSet):
         """Return a JSON array of {catchment_id, organic_amount, residual_amount, ratio}."""
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
-        organic = _get_organic_amounts(country, year, nuts_prefixes)
+        organic = _get_organic_amounts(
+            country, year, nuts_prefixes, user=request.user
+        )
         res_map = {
             r["catchment_id"]: r["amount"]
             for r in _get_collection_amount(
-                country, year, ["Residual waste"], nuts_prefixes
+                country, year, ["Residual waste"], nuts_prefixes, user=request.user
             )
         }
         all_ids = set(organic) | set(res_map)
@@ -2362,13 +2501,21 @@ class WasteRatioViewSet(WasteAtlasViewSet):
         bio = {
             r["catchment_id"]: r["amount"]
             for r in _get_collection_amount(
-                country, year, ["Biowaste", "Food waste"], nuts_prefixes
+                country,
+                year,
+                ["Biowaste", "Food waste"],
+                nuts_prefixes,
+                user=request.user,
             )
         }
         res = {
             r["catchment_id"]: r["amount"]
             for r in _get_collection_amount(
-                country, year, ["Residual waste"], nuts_prefixes
+                country,
+                year,
+                ["Residual waste"],
+                nuts_prefixes,
+                user=request.user,
             )
         }
         all_ids = set(bio) | set(res)
@@ -2415,6 +2562,7 @@ class CollectionSupportViewSet(WasteAtlasViewSet):
             year,
             ["Biowaste", "Food waste"],
             nuts_prefixes,
+            user=request.user,
         )
 
         collection_ids = [
@@ -2496,6 +2644,7 @@ class RegularPlasticCollectionSupportViewSet(WasteAtlasViewSet):
             year,
             ["Biowaste", "Food waste"],
             nuts_prefixes,
+            user=request.user,
         )
 
         collection_ids = [
@@ -2569,7 +2718,7 @@ class PaperBagsStatusViewSet(WasteAtlasViewSet):
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
         data = _get_material_status(
-            country, year, _PAPER_BAGS_MATERIAL_ID, nuts_prefixes
+            country, year, _PAPER_BAGS_MATERIAL_ID, nuts_prefixes, user=request.user
         )
         serializer = CatchmentMaterialStatusSerializer(data, many=True)
         return Response(serializer.data)
@@ -2593,7 +2742,7 @@ class PlasticBagsStatusViewSet(WasteAtlasViewSet):
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
         data = _get_material_status(
-            country, year, _PLASTIC_BAGS_MATERIAL_ID, nuts_prefixes
+            country, year, _PLASTIC_BAGS_MATERIAL_ID, nuts_prefixes, user=request.user
         )
         serializer = CatchmentMaterialStatusSerializer(data, many=True)
         return Response(serializer.data)
@@ -2620,7 +2769,11 @@ class RegularPlasticBagsStatusViewSet(WasteAtlasViewSet):
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
         data = _get_material_status(
-            country, year, _REGULAR_PLASTIC_BAGS_MATERIAL_ID, nuts_prefixes
+            country,
+            year,
+            _REGULAR_PLASTIC_BAGS_MATERIAL_ID,
+            nuts_prefixes,
+            user=request.user,
         )
         serializer = CatchmentMaterialStatusSerializer(data, many=True)
         return Response(serializer.data)
@@ -2654,6 +2807,7 @@ class FoodWasteCategoryViewSet(WasteAtlasViewSet):
             year,
             ["Biowaste", "Food waste"],
             nuts_prefixes,
+            user=request.user,
         )
 
         # Step 2: batch-fetch allowed material IDs (11-14) for selected collections
@@ -2717,6 +2871,7 @@ class ConnectionRateViewSet(WasteAtlasViewSet):
             year,
             ["Biowaste", "Food waste"],
             nuts_prefixes,
+            user=request.user,
         )
 
         collection_ids = [row["collection_id"] for row in best.values()]
@@ -2756,6 +2911,7 @@ class ParticipationPolicyViewSet(WasteAtlasViewSet):
             ["Biowaste", "Food waste"],
             nuts_prefixes,
             extra_fields=("participation_policy",),
+            user=request.user,
         ).items():
             value = (
                 "no_bio_collection"
@@ -2787,14 +2943,15 @@ class CatchmentPopulationViewSet(WasteAtlasViewSet):
         """Return a JSON array of {catchment_id, population, population_density}."""
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
+        user = request.user
         population_attribute_id = _resolved_population_attribute_id()
 
         qs = (
             CollectionCatchment.objects.filter(
                 _country_filter_q("", country),
                 collections__valid_from__year=year,
-                collections__publication_status=_PUBLISHED,
             )
+            .filter(_publication_q(user, prefix="collections__"))
             .distinct()
             .values_list("id", flat=False)
         )
@@ -2816,8 +2973,8 @@ class CatchmentPopulationViewSet(WasteAtlasViewSet):
             CollectionCatchment.objects.filter(
                 _country_filter_q("", country),
                 collections__valid_from__year=year,
-                collections__publication_status=_PUBLISHED,
             )
+            .filter(_publication_q(user, prefix="collections__"))
             .distinct()
             .annotate(
                 population=Subquery(pop_sq, output_field=FloatField()),
@@ -2869,6 +3026,7 @@ class BiowasteImpurityViewSet(WasteAtlasViewSet):
             collection_year,
             ["Biowaste", "Food waste"],
             nuts_prefixes,
+            user=request.user,
         )
 
         collection_ids = [row["collection_id"] for row in best.values()]
@@ -2931,6 +3089,7 @@ class WeeklyBpAccessDaysViewSet(WasteAtlasViewSet):
             year,
             ["Biowaste", "Food waste"],
             nuts_prefixes,
+            user=request.user,
         )
 
         collection_ids = [row["collection_id"] for row in best.values()]
@@ -2966,7 +3125,9 @@ class WeeklyBpAccessDaysViewSet(WasteAtlasViewSet):
         return Response(serializer.data)
 
 
-def _collection_system_conflicts(country, year, nuts_prefixes, waste_categories):
+def _collection_system_conflicts(
+    country, year, nuts_prefixes, waste_categories, user=None
+):
     """Catchments where >1 distinct collection system competes for one slot.
 
     Mirrors the scope of the ``collection_system`` theme family
@@ -2975,7 +3136,7 @@ def _collection_system_conflicts(country, year, nuts_prefixes, waste_categories)
     holds more than one distinct ``collection_system`` name for it, because the
     map can only display a single (priority-triaged) system per catchment.
     """
-    qs = Collection.objects.published().filter(
+    qs = _collection_qs(user).filter(
         _country_filter_q("catchment__", country),
         valid_from__year=year,
     )
@@ -3018,11 +3179,7 @@ def _collection_system_conflicts(country, year, nuts_prefixes, waste_categories)
 # shaped for ``CatchmentConflictSerializer``.  Themes not listed here have no
 # maintainer conflict aid yet and resolve to an empty result.
 _CONFLICT_DETECTORS = {
-    "collection_system": lambda country, year, nuts_prefixes: (
-        _collection_system_conflicts(
-            country, year, nuts_prefixes, ["Biowaste", "Food waste"]
-        )
-    ),
+    "collection_system": "_collection_system_conflicts",
 }
 
 
@@ -3057,8 +3214,17 @@ class CollectionConflictViewSet(WasteAtlasViewSet):
         nuts_prefixes = _parse_nuts_prefixes(request)
         theme = request.query_params.get("theme", "collection_system")
 
-        detector = _CONFLICT_DETECTORS.get(theme)
-        conflicts = detector(country, year, nuts_prefixes) if detector else []
+        detector_name = _CONFLICT_DETECTORS.get(theme)
+        if detector_name == "_collection_system_conflicts":
+            conflicts = _collection_system_conflicts(
+                country,
+                year,
+                nuts_prefixes,
+                ["Biowaste", "Food waste"],
+                user=request.user,
+            )
+        else:
+            conflicts = []
 
         serializer = CatchmentConflictSerializer(conflicts, many=True)
         return Response(serializer.data)

--- a/sources/waste_collection/waste_atlas/viewsets.py
+++ b/sources/waste_collection/waste_atlas/viewsets.py
@@ -34,6 +34,9 @@ from sources.waste_collection.models import (
     CollectionPropertyValue,
     Collector,
 )
+from utils.object_management.models import UserCreatedObject
+
+_PUBLISHED = UserCreatedObject.STATUS_PUBLISHED
 
 from .serializers import (
     GEOMETRY_SIMPLIFY_TOLERANCE,
@@ -277,7 +280,7 @@ def _select_primary_collections(
     extra_fields=(),
     extra_filters=None,
 ):
-    qs = Collection.objects.filter(
+    qs = Collection.objects.published().filter(
         _country_filter_q("catchment__", country),
         valid_from__year=year,
     )
@@ -423,6 +426,7 @@ def _active_collector_scope(country, year, nuts_prefixes):
         _country_filter_q("catchment__", country),
         catchment__isnull=False,
         collection__valid_from__year=year,
+        collection__publication_status=_PUBLISHED,
     )
     return _apply_nuts_prefix_filter(qs, nuts_prefixes, catchment_path="catchment__")
 
@@ -451,6 +455,7 @@ class CatchmentViewSet(WasteAtlasReadOnlyModelViewSet):
             CollectionCatchment.objects.filter(
                 _country_filter_q("", country),
                 collections__valid_from__year=year,
+                collections__publication_status=_PUBLISHED,
                 region__borders__isnull=False,
             )
             .distinct()
@@ -578,7 +583,7 @@ class CollectionOrgaLevelViewSet(WasteAtlasViewSet):
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
 
-        qs = Collection.objects.filter(
+        qs = Collection.objects.published().filter(
             _country_filter_q("catchment__", country),
             catchment__isnull=False,
             valid_from__year=year,
@@ -852,7 +857,7 @@ class GreenWasteCollectionSystemCountViewSet(WasteAtlasViewSet):
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
         qs = _filter_by_waste_categories(
-            Collection.objects.filter(
+            Collection.objects.published().filter(
                 _country_filter_q("catchment__", country),
                 valid_from__year=year,
             ),
@@ -952,7 +957,7 @@ def _get_collection_count(
     Non-door-to-door catchments are excluded (they have no frequency data).
     """
     qs = _filter_by_waste_categories(
-        Collection.objects.filter(
+        Collection.objects.published().filter(
             _country_filter_q("catchment__", country),
             valid_from__year=year,
             collection_system__name="Door to door",
@@ -1488,7 +1493,7 @@ def _get_collection_amount(
     # Step 2: map catchments → all collection IDs (any year)
     # ------------------------------------------------------------------
     all_col_rows = _filter_by_waste_categories(
-        Collection.objects.filter(
+        Collection.objects.published().filter(
             catchment_id__in=catchment_ids,
         ),
         waste_categories,
@@ -1760,6 +1765,7 @@ def _get_green_waste_collection_amount(country, year, nuts_prefixes=()):
             CollectionCatchment.objects.filter(
                 _country_filter_q("", country),
                 collections__valid_from__year=year,
+                collections__publication_status=_PUBLISHED,
             ).distinct(),
             nuts_prefixes,
         ).values_list("id", flat=True)
@@ -1778,7 +1784,7 @@ def _get_green_waste_collection_amount(country, year, nuts_prefixes=()):
         return []
 
     all_col_rows = _filter_by_waste_categories(
-        Collection.objects.filter(
+        Collection.objects.published().filter(
             catchment_id__in=catchment_ids,
         ),
         _GREEN_WASTE_CATEGORY_NAMES,
@@ -2015,7 +2021,7 @@ def _get_min_bin_size(
     Only door-to-door collections carry meaningful bin size data.
     """
     qs = _filter_by_waste_categories(
-        Collection.objects.filter(
+        Collection.objects.published().filter(
             _country_filter_q("catchment__", country),
             valid_from__year=year,
             collection_system__name="Door to door",
@@ -2061,7 +2067,7 @@ def _get_required_bin_capacity(
     not_specified) for the primary door-to-door collection per catchment.
     """
     qs = _filter_by_waste_categories(
-        Collection.objects.filter(
+        Collection.objects.published().filter(
             _country_filter_q("catchment__", country),
             valid_from__year=year,
             collection_system__name="Door to door",
@@ -2787,6 +2793,7 @@ class CatchmentPopulationViewSet(WasteAtlasViewSet):
             CollectionCatchment.objects.filter(
                 _country_filter_q("", country),
                 collections__valid_from__year=year,
+                collections__publication_status=_PUBLISHED,
             )
             .distinct()
             .values_list("id", flat=False)
@@ -2809,6 +2816,7 @@ class CatchmentPopulationViewSet(WasteAtlasViewSet):
             CollectionCatchment.objects.filter(
                 _country_filter_q("", country),
                 collections__valid_from__year=year,
+                collections__publication_status=_PUBLISHED,
             )
             .distinct()
             .annotate(
@@ -2967,7 +2975,7 @@ def _collection_system_conflicts(country, year, nuts_prefixes, waste_categories)
     holds more than one distinct ``collection_system`` name for it, because the
     map can only display a single (priority-triaged) system per catchment.
     """
-    qs = Collection.objects.filter(
+    qs = Collection.objects.published().filter(
         _country_filter_q("catchment__", country),
         valid_from__year=year,
     )

--- a/sources/waste_collection/waste_atlas/viewsets.py
+++ b/sources/waste_collection/waste_atlas/viewsets.py
@@ -35,6 +35,7 @@ from sources.waste_collection.models import (
     Collector,
 )
 from utils.object_management.models import UserCreatedObject
+
 from .serializers import (
     GEOMETRY_SIMPLIFY_TOLERANCE,
     CatchmentAccessControlSerializer,

--- a/sources/waste_collection/waste_atlas/viewsets.py
+++ b/sources/waste_collection/waste_atlas/viewsets.py
@@ -458,9 +458,10 @@ def _active_collector_scope(country, year, nuts_prefixes, user=None):
     """Return collectors with collection records in the selected atlas year."""
     qs = Collector.objects.filter(
         _country_filter_q("catchment__", country),
+        _publication_q(user, prefix="collection__"),
         catchment__isnull=False,
         collection__valid_from__year=year,
-    ).filter(_publication_q(user, prefix="collection__"))
+    )
     return _apply_nuts_prefix_filter(qs, nuts_prefixes, catchment_path="catchment__")
 
 
@@ -488,10 +489,10 @@ class CatchmentViewSet(WasteAtlasReadOnlyModelViewSet):
         qs = (
             CollectionCatchment.objects.filter(
                 _country_filter_q("", country),
+                _publication_q(user, prefix="collections__"),
                 collections__valid_from__year=year,
                 region__borders__isnull=False,
             )
-            .filter(_publication_q(user, prefix="collections__"))
             .distinct()
             .select_related("region", "region__borders")
         )
@@ -1866,10 +1867,9 @@ def _get_green_waste_collection_amount(country, year, nuts_prefixes=(), user=Non
         _apply_nuts_prefix_filter(
             CollectionCatchment.objects.filter(
                 _country_filter_q("", country),
+                _publication_q(user, prefix="collections__"),
                 collections__valid_from__year=year,
-            )
-            .filter(_publication_q(user, prefix="collections__"))
-            .distinct(),
+            ).distinct(),
             nuts_prefixes,
         ).values_list("id", flat=True)
     )
@@ -2945,9 +2945,9 @@ class CatchmentPopulationViewSet(WasteAtlasViewSet):
         qs = (
             CollectionCatchment.objects.filter(
                 _country_filter_q("", country),
+                _publication_q(user, prefix="collections__"),
                 collections__valid_from__year=year,
             )
-            .filter(_publication_q(user, prefix="collections__"))
             .distinct()
             .values_list("id", flat=False)
         )
@@ -2968,9 +2968,9 @@ class CatchmentPopulationViewSet(WasteAtlasViewSet):
         qs = (
             CollectionCatchment.objects.filter(
                 _country_filter_q("", country),
+                _publication_q(user, prefix="collections__"),
                 collections__valid_from__year=year,
             )
-            .filter(_publication_q(user, prefix="collections__"))
             .distinct()
             .annotate(
                 population=Subquery(pop_sq, output_field=FloatField()),

--- a/sources/waste_collection/waste_atlas/viewsets.py
+++ b/sources/waste_collection/waste_atlas/viewsets.py
@@ -2432,9 +2432,7 @@ class OrganicCollectionAmountViewSet(WasteAtlasViewSet):
         """Return a JSON array of {catchment_id, amount}."""
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
-        organic = _get_organic_amounts(
-            country, year, nuts_prefixes, user=request.user
-        )
+        organic = _get_organic_amounts(country, year, nuts_prefixes, user=request.user)
         data = [{"catchment_id": cid, "amount": amt} for cid, amt in organic.items()]
         serializer = CatchmentCollectionAmountSerializer(data, many=True)
         return Response(serializer.data)
@@ -2454,9 +2452,7 @@ class OrganicWasteRatioViewSet(WasteAtlasViewSet):
         """Return a JSON array of {catchment_id, organic_amount, residual_amount, ratio}."""
         country, year = _parse_country_year(request)
         nuts_prefixes = _parse_nuts_prefixes(request)
-        organic = _get_organic_amounts(
-            country, year, nuts_prefixes, user=request.user
-        )
+        organic = _get_organic_amounts(country, year, nuts_prefixes, user=request.user)
         res_map = {
             r["catchment_id"]: r["amount"]
             for r in _get_collection_amount(

--- a/sources/waste_collection/waste_atlas/viewsets.py
+++ b/sources/waste_collection/waste_atlas/viewsets.py
@@ -35,9 +35,6 @@ from sources.waste_collection.models import (
     Collector,
 )
 from utils.object_management.models import UserCreatedObject
-
-_PUBLISHED = UserCreatedObject.STATUS_PUBLISHED
-
 from .serializers import (
     GEOMETRY_SIMPLIFY_TOLERANCE,
     CatchmentAccessControlSerializer,
@@ -72,6 +69,8 @@ from .serializers import (
     CatchmentWasteRatioSerializer,
     CatchmentWeeklyBpAccessDaysSerializer,
 )
+
+_PUBLISHED = UserCreatedObject.STATUS_PUBLISHED
 
 # Material IDs for food waste classification (Karte 4)
 _FOOD_WASTE_MATERIAL_IDS = {11, 12, 13, 14}


### PR DESCRIPTION
## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Summary

Fixes #163 — all waste atlas API endpoints now filter by `publication_status`:

1. **Publication scoping**: anonymous/non-staff users see only `published` collections.
2. **Staff bypass**: authenticated staff users (`is_staff=True`) additionally see `private` and `review` collections, enabling map-based monitoring of data-collection progress.
3. **Reverse-FK JOIN fix**: `_publication_q()` merged into the same `.filter()` call as `collections__valid_from__year` to prevent Django from creating separate SQL JOINs that could leak unpublished catchments.

### Key changes in `viewsets.py`

```python
_STAFF_VISIBLE = (STATUS_PUBLISHED, STATUS_REVIEW, STATUS_PRIVATE)

def _is_staff(user):
    return user is not None and hasattr(user, "is_staff") and user.is_staff

def _collection_qs(user=None):
    if _is_staff(user):
        return Collection.objects.filter(publication_status__in=_STAFF_VISIBLE)
    return Collection.objects.published()

def _publication_q(user=None, prefix=""):
    field = f"{prefix}publication_status"
    if _is_staff(user):
        return Q(**{f"{field}__in": _STAFF_VISIBLE})
    return Q(**{field: _PUBLISHED})
```

- All `Collection.objects.published()` / `Collection.objects.filter(...)` calls → `_collection_qs(user)`.
- All reverse-FK `collections__publication_status` filters → `_publication_q(user, prefix="collections__")` **inside the same `.filter()` call** as the year condition (single JOIN).
- `user=request.user` threaded through every viewset `list()` / `get_queryset()` → helper functions → `_select_primary_collections()` / `_active_collector_scope()`.

### Tests

- 7 publication-scoping tests + 4 staff-bypass tests in `test_viewsets.py` — all 137 pass.
- Added `publication_status="published"` to test factories in `test_waste_atlas_biowaste_amount.py` and `test_views.py`.

## Verification

- [x] Focused tests or checks were run.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed.
- [x] No secrets, raw data, or production-only configuration are included.


Link to Devin session: https://app.devin.ai/sessions/4414623038494cbb819318074f4ab222
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->