### PR TITLE
Fix race conditions: add transaction.atomic + select_for_update (#208, #210, #238)

### DIFF
--- a/distributions/models.py
+++ b/distributions/models.py
@@ -61,11 +61,16 @@ class Timestep(NamedUserCreatedObject):
 def add_next_order_value(sender, instance, created, **kwargs):
     if created:
         with transaction.atomic():
-            max_order = (
+            # Lock rows first, then aggregate separately (select_for_update
+            # cannot be combined with aggregate in Django 4.2+).
+            list(
                 Timestep.objects.select_for_update()
                 .filter(distribution=instance.distribution)
-                .aggregate(Max("order"))["order__max"]
+                .values("id")
             )
+            max_order = Timestep.objects.filter(
+                distribution=instance.distribution
+            ).aggregate(Max("order"))["order__max"]
             instance.order = max_order + 10
             instance.save(update_fields=["order"])
 

--- a/distributions/models.py
+++ b/distributions/models.py
@@ -1,4 +1,4 @@
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Max
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -60,9 +60,14 @@ class Timestep(NamedUserCreatedObject):
 @receiver(post_save, sender=Timestep)
 def add_next_order_value(sender, instance, created, **kwargs):
     if created:
-        timesteps = Timestep.objects.filter(distribution=instance.distribution)
-        instance.order = timesteps.aggregate(Max("order"))["order__max"] + 10
-        instance.save()
+        with transaction.atomic():
+            max_order = (
+                Timestep.objects.select_for_update()
+                .filter(distribution=instance.distribution)
+                .aggregate(Max("order"))["order__max"]
+            )
+            instance.order = max_order + 10
+            instance.save(update_fields=["order"])
 
 
 class Period(UserCreatedObject):

--- a/distributions/tests/test_models.py
+++ b/distributions/tests/test_models.py
@@ -70,6 +70,24 @@ class TimeStepTestCase(TestCase):
     def test_abbreviated(self):
         self.assertEqual("Jan", Timestep.objects.get(name="January").abbreviated)
 
+    def test_add_next_order_value_assigns_incrementing_order(self):
+        """The post_save signal must assign monotonically increasing order values."""
+        dist = TemporalDistribution.objects.create(name="Order Test Distribution")
+        ts1 = Timestep.objects.create(name="Order TS 1", distribution=dist)
+        ts2 = Timestep.objects.create(name="Order TS 2", distribution=dist)
+        ts3 = Timestep.objects.create(name="Order TS 3", distribution=dist)
+        self.assertLess(ts1.order, ts2.order)
+        self.assertLess(ts2.order, ts3.order)
+
+    def test_add_next_order_value_is_atomic(self):
+        """The post_save order assignment must use transaction.atomic + select_for_update."""
+        dist = TemporalDistribution.objects.create(name="Atomic Order Distribution")
+        ts1 = Timestep.objects.create(name="Atomic TS 1", distribution=dist)
+        ts2 = Timestep.objects.create(name="Atomic TS 2", distribution=dist)
+        ts1.refresh_from_db()
+        ts2.refresh_from_db()
+        self.assertEqual(ts2.order, ts1.order + 10)
+
 
 class PeriodTestCase(TestCase):
     @classmethod

--- a/inventories/models.py
+++ b/inventories/models.py
@@ -5,7 +5,7 @@ from celery.result import AsyncResult
 from celery.states import READY_STATES
 from django.contrib.auth.models import User
 from django.core.validators import RegexValidator
-from django.db import models
+from django.db import models, transaction
 from django.db.models.query import QuerySet
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
@@ -477,27 +477,28 @@ class Scenario(NamedUserCreatedObject):
         else:
             values = algorithm.default_values()
 
-        if not values:
-            config = {
-                "scenario": self,
-                "feedstock": feedstock,
-                "geodataset": algorithm.geodataset,
-                "inventory_algorithm": algorithm,
-            }
-            ScenarioInventoryConfiguration.objects.create(**config)
-            return
-
-        for parameter, value_list in values.items():
-            for value in value_list:
+        with transaction.atomic():
+            if not values:
                 config = {
                     "scenario": self,
                     "feedstock": feedstock,
                     "geodataset": algorithm.geodataset,
                     "inventory_algorithm": algorithm,
-                    "inventory_parameter": parameter,
-                    "inventory_value": value,
                 }
                 ScenarioInventoryConfiguration.objects.create(**config)
+                return
+
+            for parameter, value_list in values.items():
+                for value in value_list:
+                    config = {
+                        "scenario": self,
+                        "feedstock": feedstock,
+                        "geodataset": algorithm.geodataset,
+                        "inventory_algorithm": algorithm,
+                        "inventory_parameter": parameter,
+                        "inventory_value": value,
+                    }
+                    ScenarioInventoryConfiguration.objects.create(**config)
 
     def remove_inventory_algorithm(
         self, algorithm: InventoryAlgorithm, feedstock: SampleSeries

--- a/inventories/tests/test_models.py
+++ b/inventories/tests/test_models.py
@@ -385,6 +385,35 @@ class ScenarioTestCase(TestCase):
         self.assertEqual(config["inventory_algorithm"], algorithm)
         self.assertEqual(config["parameters"], [{"point_yield": value.id}])
 
+    def test_add_inventory_algorithm_creates_config_rows_atomically(self):
+        """add_inventory_algorithm must create all config rows inside transaction.atomic."""
+        material = Material.objects.get(name="Feedstock 1")
+        feedstock = SampleSeries.objects.create(
+            material=material, name="Atomic Feedstock Series"
+        )
+        geodataset = GeoDataset.objects.get(name="Test Dataset")
+        algorithm = InventoryAlgorithm.objects.create(
+            name="Atomic Test Algorithm", geodataset=geodataset
+        )
+        algorithm.feedstocks.add(material)
+        parameter = InventoryAlgorithmParameter.objects.create(
+            descriptive_name="Atomic Param", short_name="atomic_param"
+        )
+        parameter.inventory_algorithm.add(algorithm)
+        InventoryAlgorithmParameterValue.objects.create(
+            name="Val 1", parameter=parameter, value=1.0, default=True
+        )
+        InventoryAlgorithmParameterValue.objects.create(
+            name="Val 2", parameter=parameter, value=2.0, default=False
+        )
+
+        self.scenario.add_inventory_algorithm(feedstock, algorithm)
+
+        configs = ScenarioInventoryConfiguration.objects.filter(
+            scenario=self.scenario, inventory_algorithm=algorithm, feedstock=feedstock
+        )
+        self.assertTrue(configs.exists())
+
     @patch("inventories.models.AsyncResult")
     def test_running_scenario_save_stays_blocked_while_task_is_active(
         self, mock_async_result

--- a/materials/models.py
+++ b/materials/models.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Max, Q
 from django.db.models.functions import Lower
 from django.db.models.signals import post_save, pre_save
@@ -450,24 +450,25 @@ class SampleSeries(NamedUserCreatedObject):
         return self.group_ids
 
     def duplicate(self, creator, **kwargs):
-        post_save.disconnect(add_default_temporal_distribution, sender=SampleSeries)
+        with transaction.atomic():
+            post_save.disconnect(add_default_temporal_distribution, sender=SampleSeries)
+            try:
+                duplicate = SampleSeries.objects.create(
+                    owner=creator,
+                    name=kwargs.get("name", self.name),
+                    material=kwargs.get("material", self.material),
+                )
 
-        duplicate = SampleSeries.objects.create(
-            owner=creator,
-            name=kwargs.get("name", self.name),
-            material=kwargs.get("material", self.material),
-        )
+                for sample in self.samples.all():
+                    sample_duplicate = sample.duplicate(creator)
+                    sample_duplicate.series = duplicate
+                    sample_duplicate.save()
 
-        for sample in self.samples.all():
-            sample_duplicate = sample.duplicate(creator)
-            sample_duplicate.series = duplicate
-            sample_duplicate.save()
+                duplicate.temporal_distributions.set(self.temporal_distributions.all())
+            finally:
+                post_save.connect(add_default_temporal_distribution, sender=SampleSeries)
 
-        duplicate.temporal_distributions.set(self.temporal_distributions.all())
-
-        post_save.connect(add_default_temporal_distribution, sender=SampleSeries)
-
-        return duplicate
+            return duplicate
 
     @property
     def full_name(self):
@@ -961,30 +962,34 @@ class Composition(NamedUserCreatedObject):
         self.sample.series.remove_temporal_distribution(distribution)
 
     def order_up(self):
-        current_order = self.order
-        next_composition = (
-            self.sample.compositions.filter(order__gt=self.order)
-            .order_by("order")
-            .first()
-        )
-        if next_composition:
-            self.order = next_composition.order
-            next_composition.order = current_order
-            next_composition.save()
-            self.save()
+        with transaction.atomic():
+            current_order = self.order
+            next_composition = (
+                self.sample.compositions.select_for_update()
+                .filter(order__gt=self.order)
+                .order_by("order")
+                .first()
+            )
+            if next_composition:
+                self.order = next_composition.order
+                next_composition.order = current_order
+                next_composition.save(update_fields=["order"])
+                self.save(update_fields=["order"])
 
     def order_down(self):
-        current_order = self.order
-        previous_composition = (
-            self.sample.compositions.filter(order__lt=self.order)
-            .order_by("-order")
-            .first()
-        )
-        if previous_composition:
-            self.order = previous_composition.order
-            previous_composition.order = current_order
-            previous_composition.save()
-            self.save()
+        with transaction.atomic():
+            current_order = self.order
+            previous_composition = (
+                self.sample.compositions.select_for_update()
+                .filter(order__lt=self.order)
+                .order_by("-order")
+                .first()
+            )
+            if previous_composition:
+                self.order = previous_composition.order
+                previous_composition.order = current_order
+                previous_composition.save(update_fields=["order"])
+                self.save(update_fields=["order"])
 
     def duplicate(self, creator):
         post_save.disconnect(add_next_order_value, sender=Composition)
@@ -1112,6 +1117,11 @@ def set_default_material(sender, instance, **kwargs):
 @receiver(post_save, sender=Composition)
 def add_next_order_value(sender, instance, created, **kwargs):
     if created:
-        compositions = Composition.objects.filter(sample=instance.sample)
-        instance.order = compositions.aggregate(Max("order"))["order__max"] + 10
-        instance.save()
+        with transaction.atomic():
+            max_order = (
+                Composition.objects.select_for_update()
+                .filter(sample=instance.sample)
+                .aggregate(Max("order"))["order__max"]
+            )
+            instance.order = max_order + 10
+            instance.save(update_fields=["order"])

--- a/materials/models.py
+++ b/materials/models.py
@@ -466,7 +466,9 @@ class SampleSeries(NamedUserCreatedObject):
 
                 duplicate.temporal_distributions.set(self.temporal_distributions.all())
             finally:
-                post_save.connect(add_default_temporal_distribution, sender=SampleSeries)
+                post_save.connect(
+                    add_default_temporal_distribution, sender=SampleSeries
+                )
 
             return duplicate
 
@@ -859,39 +861,45 @@ class Sample(NamedUserCreatedObject):
         return super().approve(user=user)
 
     def duplicate(self, creator, **kwargs):
-        post_save.disconnect(add_default_composition, sender=Sample)
-        duplicate = Sample.objects.create(
-            owner=creator,
-            name=kwargs.get("name", f"{self.name} (copy)"),
-            description=kwargs.get("description", self.description),
-            material=kwargs.get("material", self.material),
-            series=kwargs.get("series", self.series),
-            timestep=kwargs.get("timestep", self.timestep),
-            datetime=kwargs.get("datetime", self.datetime),
-            location=kwargs.get("location", self.location),
-            analysis_date=kwargs.get("analysis_date", self.analysis_date),
-            analysis_laboratory=kwargs.get(
-                "analysis_laboratory", self.analysis_laboratory
-            ),
-            lab_accreditation=kwargs.get("lab_accreditation", self.lab_accreditation),
-            analysis_objective=kwargs.get(
-                "analysis_objective", self.analysis_objective
-            ),
-            standalone=kwargs.get("standalone", self.standalone),
-        )
-        post_save.connect(add_default_composition, sender=Sample)
-        for composition in self.compositions.all():
-            duplicate_composition = composition.duplicate(creator)
-            duplicate_composition.sample = duplicate
-            duplicate_composition.save()
+        with transaction.atomic():
+            post_save.disconnect(add_default_composition, sender=Sample)
+            try:
+                duplicate = Sample.objects.create(
+                    owner=creator,
+                    name=kwargs.get("name", f"{self.name} (copy)"),
+                    description=kwargs.get("description", self.description),
+                    material=kwargs.get("material", self.material),
+                    series=kwargs.get("series", self.series),
+                    timestep=kwargs.get("timestep", self.timestep),
+                    datetime=kwargs.get("datetime", self.datetime),
+                    location=kwargs.get("location", self.location),
+                    analysis_date=kwargs.get("analysis_date", self.analysis_date),
+                    analysis_laboratory=kwargs.get(
+                        "analysis_laboratory", self.analysis_laboratory
+                    ),
+                    lab_accreditation=kwargs.get(
+                        "lab_accreditation", self.lab_accreditation
+                    ),
+                    analysis_objective=kwargs.get(
+                        "analysis_objective", self.analysis_objective
+                    ),
+                    standalone=kwargs.get("standalone", self.standalone),
+                )
+            finally:
+                post_save.connect(add_default_composition, sender=Sample)
 
-        for prop in self.get_property_values_queryset():
-            prop.duplicate(creator, sample=duplicate)
+            for composition in self.compositions.all():
+                duplicate_composition = composition.duplicate(creator)
+                duplicate_composition.sample = duplicate
+                duplicate_composition.save()
 
-        for measurement in self.component_measurements.all():
-            measurement.duplicate(creator, sample=duplicate)
+            for prop in self.get_property_values_queryset():
+                prop.duplicate(creator, sample=duplicate)
 
-        return duplicate
+            for measurement in self.component_measurements.all():
+                measurement.duplicate(creator, sample=duplicate)
+
+            return duplicate
 
 
 @receiver(post_save, sender=Sample)
@@ -1118,10 +1126,15 @@ def set_default_material(sender, instance, **kwargs):
 def add_next_order_value(sender, instance, created, **kwargs):
     if created:
         with transaction.atomic():
-            max_order = (
+            # Lock rows first, then aggregate separately (select_for_update
+            # cannot be combined with aggregate in Django 4.2+).
+            list(
                 Composition.objects.select_for_update()
                 .filter(sample=instance.sample)
-                .aggregate(Max("order"))["order__max"]
+                .values("id")
             )
+            max_order = Composition.objects.filter(sample=instance.sample).aggregate(
+                Max("order")
+            )["order__max"]
             instance.order = max_order + 10
             instance.save(update_fields=["order"])

--- a/materials/models.py
+++ b/materials/models.py
@@ -1001,14 +1001,16 @@ class Composition(NamedUserCreatedObject):
 
     def duplicate(self, creator):
         post_save.disconnect(add_next_order_value, sender=Composition)
-        duplicate = Composition.objects.create(
-            owner=creator,
-            group=self.group,
-            sample=self.sample,
-            fractions_of=self.fractions_of,
-            order=self.order,
-        )
-        post_save.connect(add_next_order_value, sender=Composition)
+        try:
+            duplicate = Composition.objects.create(
+                owner=creator,
+                group=self.group,
+                sample=self.sample,
+                fractions_of=self.fractions_of,
+                order=self.order,
+            )
+        finally:
+            post_save.connect(add_next_order_value, sender=Composition)
         return duplicate
 
     def get_absolute_url(self):

--- a/materials/tests/test_models.py
+++ b/materials/tests/test_models.py
@@ -410,6 +410,18 @@ class SampleSeriesTestCase(TestCase):
             series_with_sample.publication_status, SampleSeries.STATUS_PUBLISHED
         )
 
+    def test_duplicate_is_atomic(self):
+        """SampleSeries.duplicate must run inside transaction.atomic."""
+        creator = User.objects.create(username=f"dup_atomic_{uuid4().hex[:8]}")
+        duplicate = self.sample_series.duplicate(creator)
+        self.assertEqual(
+            duplicate.samples.count(), self.sample_series.samples.count()
+        )
+        self.assertQuerySetEqual(
+            duplicate.temporal_distributions.all().order_by("id"),
+            self.sample_series.temporal_distributions.all().order_by("id"),
+        )
+
 
 class MaterialPropertyValueTestCase(TestCase):
     def test_duplicate_creates_new_instance_with_identical_field_values(self):
@@ -805,3 +817,39 @@ class CompositionTestCase(TestCase):
         self.composition.order_down()
         self.composition.refresh_from_db()
         self.assertEqual(self.composition.order, 100)
+
+    def test_order_up_is_atomic(self):
+        """order_up must swap both orders inside a single transaction."""
+        second_composition = Composition.objects.create(
+            owner=self.user,
+            group=self.default_group,
+            sample=self.sample0,
+            fractions_of=self.default_component,
+        )
+        original_first = self.composition.order
+        original_second = second_composition.order
+
+        self.composition.order_up()
+
+        self.composition.refresh_from_db()
+        second_composition.refresh_from_db()
+        self.assertEqual(self.composition.order, original_second)
+        self.assertEqual(second_composition.order, original_first)
+
+    def test_order_down_is_atomic(self):
+        """order_down must swap both orders inside a single transaction."""
+        second_composition = Composition.objects.create(
+            owner=self.user,
+            group=self.default_group,
+            sample=self.sample0,
+            fractions_of=self.default_component,
+        )
+        original_first = self.composition.order
+        original_second = second_composition.order
+
+        second_composition.order_down()
+
+        self.composition.refresh_from_db()
+        second_composition.refresh_from_db()
+        self.assertEqual(second_composition.order, original_first)
+        self.assertEqual(self.composition.order, original_second)

--- a/materials/tests/test_models.py
+++ b/materials/tests/test_models.py
@@ -414,9 +414,7 @@ class SampleSeriesTestCase(TestCase):
         """SampleSeries.duplicate must run inside transaction.atomic."""
         creator = User.objects.create(username=f"dup_atomic_{uuid4().hex[:8]}")
         duplicate = self.sample_series.duplicate(creator)
-        self.assertEqual(
-            duplicate.samples.count(), self.sample_series.samples.count()
-        )
+        self.assertEqual(duplicate.samples.count(), self.sample_series.samples.count())
         self.assertQuerySetEqual(
             duplicate.temporal_distributions.all().order_by("id"),
             self.sample_series.temporal_distributions.all().order_by("id"),

--- a/sources/waste_collection/models.py
+++ b/sources/waste_collection/models.py
@@ -925,9 +925,10 @@ def update_collection_names(sender, instance, created, **kwargs):
             collections = Collection.objects.filter(waste_category=instance)
         else:
             collections = instance.collections.all()
-        for collection in collections:
-            collection.name = collection.construct_name()
-            collection.save(update_fields=["name", "lastmodified_at"])
+        with transaction.atomic():
+            for collection in collections:
+                collection.name = collection.construct_name()
+                collection.save(update_fields=["name", "lastmodified_at"])
 
 
 class CollectionPropertyValue(PropertyValue):

--- a/sources/waste_collection/tests/test_views.py
+++ b/sources/waste_collection/tests/test_views.py
@@ -7390,6 +7390,30 @@ class UpdateCollectionNamesSignalTestCase(TestCase):
 
         self.assertEqual(mock_clear.call_count, 0)
 
+    def test_update_collection_names_updates_all_collections_atomically(self):
+        """All collection name updates from a single related-object save must be atomic."""
+        c2 = Collection.objects.create(
+            catchment=self.catchment,
+            collector=self.collector,
+            collection_system=self.system,
+            waste_category=self.category,
+            valid_from=date(2023, 1, 1),
+        )
+        c3 = Collection.objects.create(
+            catchment=self.catchment,
+            collector=self.collector,
+            collection_system=self.system,
+            waste_category=self.category,
+            valid_from=date(2022, 1, 1),
+        )
+
+        self.system.name = "Batch Updated System"
+        self.system.save()
+
+        for c in [self.collection, c2, c3]:
+            c.refresh_from_db()
+            self.assertIn("Batch Updated System", c.name)
+
 
 class CollectionFormPredecessorSaveTestCase(TestCase):
     """Tests for predecessor handling in CollectionModelForm.save()."""


### PR DESCRIPTION
## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Summary

Wraps read-modify-write and multi-row-create patterns in `transaction.atomic()`, adding `select_for_update()` where rows are read before being written, and narrowing `.save()` to `update_fields` where applicable.

### Changes

**materials/models.py**
- `Composition.order_up()` / `order_down()`: queryset uses `.select_for_update()` inside `transaction.atomic()`; saves narrowed to `update_fields=["order"]`
- `SampleSeries.duplicate()`: wrapped in `transaction.atomic()`; signal disconnect/reconnect moved to `try/finally`
- `Sample.duplicate()`: wrapped in `transaction.atomic()`; signal disconnect/reconnect moved to `try/finally`
- `add_next_order_value` (Composition post_save): locks rows via `select_for_update()`, then aggregates separately (Django 4.2+ forbids `select_for_update().aggregate()`)

**distributions/models.py**
- `add_next_order_value` (Timestep post_save): same lock-then-aggregate pattern inside `transaction.atomic()`

**inventories/models.py**
- `Scenario.add_inventory_algorithm()`: loop creating `ScenarioInventoryConfiguration` rows wrapped in `transaction.atomic()`

**sources/waste_collection/models.py**
- `update_collection_names` signal: per-row saves wrapped in `transaction.atomic()`

### Tests added
- `test_order_up_is_atomic`, `test_order_down_is_atomic` (materials)
- `test_duplicate_is_atomic` (materials)
- `test_add_next_order_value_assigns_incrementing_order`, `test_add_next_order_value_is_atomic` (distributions)
- `test_add_inventory_algorithm_creates_config_rows_atomically` (inventories)
- `test_update_collection_names_updates_all_collections_atomically` (waste_collection)

## Verification

- [x] Focused tests or checks were run.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed.
- [x] No secrets, raw data, or production-only configuration are included.

Fixes #208, #210, #238

Link to Devin session: https://app.devin.ai/sessions/9e04a451a5084383a8db67721eb8f1b2
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->