### PR TITLE
fix: maps exception-handling bugs and URL routing typos/duplicates

### DIFF
--- a/brit/README.md
+++ b/brit/README.md
@@ -78,7 +78,7 @@ The legacy `object` / `header` / `title` / `breadcrumb_page_title` fallback chai
 | `inventories` | Inventories | `inventories-explorer` | — |
 | `maps` | Maps | `maps-dashboard` | — |
 | `materials` | Materials | `materials-explorer` | — |
-| `processes` | Processes | `processes-dashboard` | — |
+| `processes` | Processes | `processes:dashboard` | — |
 | `properties` | Properties | `properties-dashboard` | — |
 | `sources` | Sources | `sources-explorer` | — |
 | `utils` | Utilities | `utils-dashboard` | — |

--- a/brit/tests/test_urls.py
+++ b/brit/tests/test_urls.py
@@ -1,5 +1,5 @@
 from django.test import SimpleTestCase
-from django.urls import resolve, reverse
+from django.urls import reverse
 
 
 class SessionUrlRoutingTests(SimpleTestCase):

--- a/brit/tests/test_urls.py
+++ b/brit/tests/test_urls.py
@@ -1,0 +1,12 @@
+from django.test import SimpleTestCase
+from django.urls import resolve, reverse
+
+
+class SessionUrlRoutingTests(SimpleTestCase):
+    def test_set_session_url_resolves(self):
+        url = reverse("set_session")
+        self.assertEqual(url, "/set_session/")
+
+    def test_get_session_url_resolves(self):
+        url = reverse("get_session")
+        self.assertEqual(url, "/get_session/")

--- a/brit/urls.py
+++ b/brit/urls.py
@@ -72,8 +72,8 @@ urlpatterns = [
         TemplateView.as_view(template_name="robots.txt", content_type="text/plain"),
     ),
     path("cache-test/", CacheTestView.as_view(), name="cache_test"),
-    path("set_settion/", set_session, name="set_session"),
-    path("get_settion/", get_session, name="get_session"),
+    path("set_session/", set_session, name="set_session"),
+    path("get_session/", get_session, name="get_session"),
     path("<str:short_code>/", DynamicRedirectView.as_view(), name="redirect"),
 ]
 

--- a/case_studies/closecycle/templates/closecycle/showcase_detail.html
+++ b/case_studies/closecycle/templates/closecycle/showcase_detail.html
@@ -36,7 +36,7 @@
             <ul>
                 {% for proc in involved_processes %}
                     <li>
-                        <a href="{% url 'processes:type_detail' proc.id %}">{{ proc.name }}</a>
+                        <a href="{% url 'processes:processtype-detail' proc.id %}">{{ proc.name }}</a>
                     </li>
                 {% endfor %}
             </ul>

--- a/inventories/urls.py
+++ b/inventories/urls.py
@@ -99,7 +99,7 @@ urlpatterns = [
     path(
         "scenarios/<int:scenario_pk>/materials/<int:material_pk>/<int:component_pk>/seasonal_distributions/create/",
         SeasonalDistributionCreateView.as_view(),
-        name="seasonal-distribution-create",
+        name="scenario-seasonal-distribution-create",
     ),
     path(
         "scenarios/<int:pk>/<int:algorithm_pk>/<int:feedstock_pk>/",

--- a/maps/tests/test_views.py
+++ b/maps/tests/test_views.py
@@ -21,7 +21,7 @@ from rest_framework.viewsets import ModelViewSet
 
 from bibliography.models import Source
 from maps.mixins import GeoJSONMixin
-from maps.views import CatchmentCreateMergeLauView, CatchmentRegionSummaryAPIView
+from maps.views import CatchmentCreateMergeLauView
 from utils.properties.models import Unit
 from utils.tests.testcases import (
     AbstractTestCases,

--- a/maps/tests/test_views.py
+++ b/maps/tests/test_views.py
@@ -21,7 +21,7 @@ from rest_framework.viewsets import ModelViewSet
 
 from bibliography.models import Source
 from maps.mixins import GeoJSONMixin
-from maps.views import CatchmentCreateMergeLauView
+from maps.views import CatchmentCreateMergeLauView, CatchmentRegionSummaryAPIView
 from utils.properties.models import Unit
 from utils.tests.testcases import (
     AbstractTestCases,
@@ -1065,6 +1065,100 @@ class CatchmentCRUDViewsTestCase(AbstractTestCases.UserCreatedObjectCRUDViewTest
         }
         response = self.client.post(url, data)
         self.assertEqual(302, response.status_code)
+
+    def test_create_region_borders_raises_on_empty_geoms(self):
+        url = reverse("catchment-create-merge-lau")
+        data = {
+            "name": "Empty Merge",
+            "parent_region": self.util_objects["parent_region"].pk,
+            "form-INITIAL_FORMS": 0,
+            "form-TOTAL_FORMS": 2,
+            "form-0-region": "",
+            "form-1-region": "",
+        }
+        request = RequestFactory().post(url, data)
+        request.user = self.staff_user
+        view = CatchmentCreateMergeLauView()
+        view.setup(request)
+        view.formset = Mock()
+        view.formset.cleaned_data = [{"region": None}, {"region": None}]
+        with self.assertRaises(ValueError):
+            view.create_region_borders()
+
+
+class CatchmentRegionSummaryAPIViewTestCase(ViewWithPermissionsTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.nuts_region = NutsRegion.objects.create(
+            nuts_id="AB", levl_code=0, name_latn="Nuts Summary Region"
+        )
+        cls.nuts_catchment = Catchment.objects.create(
+            region=cls.nuts_region.region_ptr
+        )
+        cls.lau_region = LauRegion.objects.create(
+            lau_id="L0001", lau_name="Lau Summary Region",
+            nuts_parent=cls.nuts_region,
+        )
+        cls.lau_catchment = Catchment.objects.create(
+            region=cls.lau_region.region_ptr
+        )
+        cls.plain_region = Region.objects.create(name="Plain Region")
+        cls.plain_catchment = Catchment.objects.create(region=cls.plain_region)
+
+    def test_nuts_catchment_returns_summary(self):
+        response = self.client.get(
+            reverse("data.catchment_region_summaries"),
+            {"pk": self.nuts_catchment.pk},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("summaries", response.data)
+
+    def test_lau_catchment_returns_summary(self):
+        response = self.client.get(
+            reverse("data.catchment_region_summaries"),
+            {"pk": self.lau_catchment.pk},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("summaries", response.data)
+
+    def test_plain_catchment_returns_empty_response(self):
+        response = self.client.get(
+            reverse("data.catchment_region_summaries"),
+            {"pk": self.plain_catchment.pk},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("summaries", response.data)
+
+    def test_no_pk_returns_empty_response(self):
+        response = self.client.get(
+            reverse("data.catchment_region_summaries"),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("summaries", response.data)
+
+
+class NutsRegionPedigreeAPITestCase(ViewWithPermissionsTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.nuts_region = NutsRegion.objects.create(
+            nuts_id="YY", levl_code=0, name_latn="Pedigree Test Region"
+        )
+
+    def test_non_existent_id_returns_404(self):
+        response = self.client.get(
+            reverse("data.nuts_region_options"),
+            {"id": 0, "direction": "children"},
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_missing_id_returns_400(self):
+        response = self.client.get(
+            reverse("data.nuts_region_options"),
+            {"direction": "children"},
+        )
+        self.assertEqual(response.status_code, 400)
 
 
 # ----------- Catchment API---------------------------------------------------------------------------------------------

--- a/maps/tests/test_views.py
+++ b/maps/tests/test_views.py
@@ -1093,16 +1093,13 @@ class CatchmentRegionSummaryAPIViewTestCase(ViewWithPermissionsTestCase):
         cls.nuts_region = NutsRegion.objects.create(
             nuts_id="AB", levl_code=0, name_latn="Nuts Summary Region"
         )
-        cls.nuts_catchment = Catchment.objects.create(
-            region=cls.nuts_region.region_ptr
-        )
+        cls.nuts_catchment = Catchment.objects.create(region=cls.nuts_region.region_ptr)
         cls.lau_region = LauRegion.objects.create(
-            lau_id="L0001", lau_name="Lau Summary Region",
+            lau_id="L0001",
+            lau_name="Lau Summary Region",
             nuts_parent=cls.nuts_region,
         )
-        cls.lau_catchment = Catchment.objects.create(
-            region=cls.lau_region.region_ptr
-        )
+        cls.lau_catchment = Catchment.objects.create(region=cls.lau_region.region_ptr)
         cls.plain_region = Region.objects.create(name="Plain Region")
         cls.plain_catchment = Catchment.objects.create(region=cls.plain_region)
 

--- a/maps/views.py
+++ b/maps/views.py
@@ -1244,6 +1244,8 @@ class CatchmentCreateMergeLauView(UserCreatedObjectCreateView):
             for form in self.formset.cleaned_data
             if form.get("region") is not None
         ]
+        if not geoms:
+            raise ValueError("Cannot create region borders: no regions selected.")
         new_geom = geoms[0]
         for geom in geoms[1:]:
             new_geom = new_geom.union(geom)
@@ -1444,7 +1446,7 @@ class CatchmentRegionSummaryAPIView(APIView):
                     region, field_labels_as_keys=True, context={"request": request}
                 )
                 return Response({"summaries": [serializer.data]})
-            except Region.nutsregion.RelatedObjectDoesNotExist:
+            except Region.lauregion.RelatedObjectDoesNotExist:
                 pass
 
         return Response({})
@@ -1488,10 +1490,6 @@ class NutsRegionPedigreeAPI(APIView):
 
         try:
             instance = NutsRegion.objects.get(id=request.query_params["id"])
-        except AttributeError as err:
-            raise NotFound(
-                "A NUTS region with the provided id does not exist."
-            ) from err
         except NutsRegion.DoesNotExist as err:
             raise NotFound(
                 "A NUTS region with the provided id does not exist."
@@ -1542,11 +1540,7 @@ class NutsAndLauCatchmentPedigreeAPI(APIView):
         try:
             catchment = Catchment.objects.get(id=request.query_params["id"])
             instance = catchment.region.nutsregion
-        except AttributeError as err:
-            raise NotFound(
-                "A NUTS region with the provided id does not exist."
-            ) from err
-        except Catchment.DoesNotExist as err:
+        except (Catchment.DoesNotExist, NutsRegion.DoesNotExist, AttributeError) as err:
             raise NotFound(
                 "A NUTS region with the provided id does not exist."
             ) from err

--- a/processes/urls.py
+++ b/processes/urls.py
@@ -14,11 +14,6 @@ urlpatterns = [
     # Dashboard
     path("dashboard/", views.ProcessDashboardView.as_view(), name="dashboard"),
     path(
-        "dashboard/",
-        views.ProcessDashboardView.as_view(),
-        name="processes-dashboard",
-    ),
-    path(
         "explorer/",
         views.ProcessDashboardView.as_view(),
         name="processes-explorer",
@@ -93,11 +88,6 @@ urlpatterns = [
     path(
         "types/",
         views.ProcessPublishedFilterView.as_view(),
-        name="type_list",
-    ),
-    path(
-        "types/",
-        views.ProcessPublishedFilterView.as_view(),
         name="processtype-list",
     ),
     path(
@@ -124,11 +114,6 @@ urlpatterns = [
         "<int:pk>/",
         views.ProcessDetailView.as_view(),
         name="process-detail",
-    ),
-    path(
-        "types/<int:pk>/",
-        views.ProcessDetailView.as_view(),
-        name="type_detail",
     ),
     path(
         "types/<int:pk>/",

--- a/sources/waste_collection/urls.py
+++ b/sources/waste_collection/urls.py
@@ -462,11 +462,6 @@ urlpatterns = [
         name="collection-list-owned",
     ),
     path(
-        "collections/review/",
-        views.CollectionReviewListView.as_view(),
-        name="collection-list-review",
-    ),
-    path(
         "collections/create/",
         views.CollectionCreateView.as_view(),
         name="collection-create",

--- a/utils/object_management/views.py
+++ b/utils/object_management/views.py
@@ -74,7 +74,7 @@ DEFAULT_BREADCRUMB_MODULES = {
     "inventories": {"label": "Inventories", "url_name": "inventories-explorer"},
     "maps": {"label": "Maps", "url_name": "maps-dashboard"},
     "materials": {"label": "Materials", "url_name": "materials-explorer"},
-    "processes": {"label": "Processes", "url_name": "processes-dashboard"},
+    "processes": {"label": "Processes", "url_name": "processes:dashboard"},
     "properties": {"label": "Properties", "url_name": "properties-dashboard"},
     "sources": {"label": "Sources", "url_name": "sources-explorer"},
     "utils": {"label": "Utilities", "url_name": "utils-dashboard"},


### PR DESCRIPTION
## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

Closes #207, closes #236.

### Maps exception-handling fixes (`maps/views.py`)

**`CatchmentRegionSummaryAPIView.get`** — The LAU-region fallback branch caught `Region.nutsregion.RelatedObjectDoesNotExist` instead of `Region.lauregion.RelatedObjectDoesNotExist`. A catchment with a plain `Region` (neither NUTS nor LAU) would 500 because the second `except` didn't match.

```diff
- except Region.nutsregion.RelatedObjectDoesNotExist:
+ except Region.lauregion.RelatedObjectDoesNotExist:
```

**`NutsRegionPedigreeAPI.get`** — `NutsRegion.objects.get(...)` never raises `AttributeError`; removed the unreachable `except AttributeError` clause. Only `NutsRegion.DoesNotExist` is needed.

**`NutsAndLauCatchmentPedigreeAPI.get`** — Consolidated the two separate `except` blocks into one `(Catchment.DoesNotExist, NutsRegion.DoesNotExist, AttributeError)` tuple, covering `region is None` (AttributeError), non-NUTS region (`NutsRegion.DoesNotExist`), and missing catchment.

**`CatchmentCreateMergeLauView.create_region_borders`** — Added a guard raising `ValueError` when the filtered `geoms` list is empty (previously `geoms[0]` would raise a bare `IndexError`).

### URL routing fixes

| File | Fix |
|---|---|
| `brit/urls.py` | `set_settion/` → `set_session/`, `get_settion/` → `get_session/` |
| `sources/waste_collection/urls.py` | Removed duplicate `collections/review/` + `collection-list-review` (kept `CollectionReviewFilterView`) |
| `processes/urls.py` | Removed duplicate `dashboard/` (kept name `dashboard`), duplicate `types/` (kept `processtype-list`), duplicate `types/<int:pk>/` (kept `processtype-detail`) |
| `inventories/urls.py` | Renamed second `seasonal-distribution-create` to `scenario-seasonal-distribution-create` |
| `closecycle/showcase_detail.html` | Updated `processes:type_detail` → `processes:processtype-detail` |

## Verification

- [x] Focused tests or checks were run.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed.
- [x] No secrets, raw data, or production-only configuration are included.

**Tests added:**
- `CatchmentRegionSummaryAPIViewTestCase` — NUTS, LAU, plain-region, and no-pk scenarios
- `NutsRegionPedigreeAPITestCase` — non-existent ID (404) and missing ID (400)
- `CatchmentCRUDViewsTestCase.test_create_region_borders_raises_on_empty_geoms`
- `brit.tests.test_urls.SessionUrlRoutingTests` — `set_session`/`get_session` URL resolution

**Test commands:**
```
brit-worktree-test -- maps.tests.test_views.CatchmentRegionSummaryAPIViewTestCase
brit-worktree-test -- maps.tests.test_views.NutsRegionPedigreeAPITestCase
brit-worktree-test -- maps.tests.test_views.CatchmentCRUDViewsTestCase.test_create_region_borders_raises_on_empty_geoms
brit-worktree-test -- brit.tests.test_urls
brit-worktree-test -- maps.tests.test_views processes.tests.test_views inventories.tests.test_views
```
All pass (9 focused + 901 broader, 3 pre-existing Redis cache failures unrelated).

Link to Devin session: https://app.devin.ai/sessions/99501832dcd44fd7869bc4c3b2bac1bb
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->