### PR TITLE
fix: user-aware source queryset in ProcessSourceInlineForm

### DIFF
--- a/processes/forms.py
+++ b/processes/forms.py
@@ -292,6 +292,26 @@ class ProcessSourceInlineForm(forms.ModelForm):
         model = ProcessSource
         fields = ("source",)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        extra_ids = set()
+        if self.instance and self.instance.pk and self.instance.source_id:
+            extra_ids.add(self.instance.source_id)
+        data = kwargs.get("data") or (args[0] if args else None)
+        if data:
+            prefix = self.prefix or ""
+            key = f"{prefix}-source" if prefix else "source"
+            val = data.get(key)
+            if val:
+                try:
+                    extra_ids.add(int(val))
+                except (ValueError, TypeError):
+                    pass
+        if extra_ids:
+            published = Source.objects.filter(publication_status="published")
+            existing = Source.objects.filter(pk__in=extra_ids)
+            self.fields["source"].queryset = published | existing
+
 
 class ProcessSourceFormSet(OrderedUniqueInlineFormSet):
     related_field_name = "source"

--- a/processes/forms.py
+++ b/processes/forms.py
@@ -293,24 +293,15 @@ class ProcessSourceInlineForm(forms.ModelForm):
         fields = ("source",)
 
     def __init__(self, *args, **kwargs):
+        request = kwargs.pop("request", None)
         super().__init__(*args, **kwargs)
-        extra_ids = set()
-        if self.instance and self.instance.pk and self.instance.source_id:
-            extra_ids.add(self.instance.source_id)
-        data = kwargs.get("data") or (args[0] if args else None)
-        if data:
-            prefix = self.prefix or ""
-            key = f"{prefix}-source" if prefix else "source"
-            val = data.get(key)
-            if val:
-                try:
-                    extra_ids.add(int(val))
-                except (ValueError, TypeError):
-                    pass
-        if extra_ids:
-            published = Source.objects.filter(publication_status="published")
-            existing = Source.objects.filter(pk__in=extra_ids)
-            self.fields["source"].queryset = published | existing
+        if request and hasattr(request, "user"):
+            from utils.object_management.permissions import filter_queryset_for_user
+
+            qs = filter_queryset_for_user(Source.objects.all(), request.user)
+            if self.instance and self.instance.pk and self.instance.source_id:
+                qs = qs | Source.objects.filter(pk=self.instance.source_id)
+            self.fields["source"].queryset = qs
 
 
 class ProcessSourceFormSet(OrderedUniqueInlineFormSet):
@@ -325,6 +316,11 @@ class ProcessSourceInline(InlineFormSetFactory):
     formset_class = ProcessSourceFormSet
     factory_kwargs = {"extra": 1, "can_delete": True}
     formset_helper_class = DynamicTableInlineFormSetHelper
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["request"] = self.request
+        return kwargs
 
 
 class ProcessMaterialInlineForm(forms.ModelForm):

--- a/processes/tests/test_views.py
+++ b/processes/tests/test_views.py
@@ -18,6 +18,7 @@ from ..models import (
     ProcessCategory,
     ProcessInfoResource,
     ProcessMaterial,
+    ProcessSource,
 )
 
 
@@ -587,6 +588,71 @@ class ProcessCRUDViewsTestCase(AbstractTestCases.UserCreatedObjectCRUDViewTestCa
         self.assertEqual(
             self.unpublished_object.process_materials.get().role,
             ProcessMaterial.Role.OUTPUT,
+        )
+
+    def test_update_with_private_source_inline_succeeds(self):
+        """Saving a process that already has a private source attached must not
+        raise an 'invalid choice' validation error on the source inline."""
+        private_source = Source.objects.create(
+            title="Owner Private Source",
+            abbreviation="OPS",
+            owner=self.owner_user,
+            publication_status="private",
+        )
+        ps = ProcessSource.objects.create(
+            process=self.unpublished_object,
+            source=private_source,
+            order=0,
+        )
+        self.client.force_login(self.owner_user)
+
+        response = self.client.post(
+            reverse(self.view_update_name, kwargs={"pk": self.unpublished_object.pk}),
+            {
+                "name": self.unpublished_object.name,
+                "short_description": self.unpublished_object.short_description,
+                "mechanism": self.unpublished_object.mechanism,
+                "description": self.unpublished_object.description or "",
+                "categories": [self.test_category.pk],
+                "process_materials-TOTAL_FORMS": "0",
+                "process_materials-INITIAL_FORMS": "0",
+                "process_materials-MIN_NUM_FORMS": "0",
+                "process_materials-MAX_NUM_FORMS": "1000",
+                "operating_parameters-TOTAL_FORMS": "0",
+                "operating_parameters-INITIAL_FORMS": "0",
+                "operating_parameters-MIN_NUM_FORMS": "0",
+                "operating_parameters-MAX_NUM_FORMS": "1000",
+                "process_authors-TOTAL_FORMS": "0",
+                "process_authors-INITIAL_FORMS": "0",
+                "process_authors-MIN_NUM_FORMS": "0",
+                "process_authors-MAX_NUM_FORMS": "1000",
+                "process_sources-TOTAL_FORMS": "1",
+                "process_sources-INITIAL_FORMS": "1",
+                "process_sources-MIN_NUM_FORMS": "0",
+                "process_sources-MAX_NUM_FORMS": "1000",
+                "process_sources-0-source": private_source.pk,
+                "process_sources-0-order": "0",
+                "process_sources-0-id": ps.pk,
+                "process_sources-0-process": self.unpublished_object.pk,
+                "links-TOTAL_FORMS": "0",
+                "links-INITIAL_FORMS": "0",
+                "links-MIN_NUM_FORMS": "0",
+                "links-MAX_NUM_FORMS": "1000",
+                "info_resources-TOTAL_FORMS": "0",
+                "info_resources-INITIAL_FORMS": "0",
+                "info_resources-MIN_NUM_FORMS": "0",
+                "info_resources-MAX_NUM_FORMS": "1000",
+            },
+        )
+
+        self.assertRedirects(
+            response,
+            reverse(self.view_detail_name, kwargs={"pk": self.unpublished_object.pk}),
+        )
+        self.assertTrue(
+            ProcessSource.objects.filter(
+                process=self.unpublished_object, source=private_source
+            ).exists()
         )
 
 


### PR DESCRIPTION
## Summary

`ProcessSourceInlineForm.source` had a hardcoded queryset `Source.objects.filter(publication_status="published")` which caused "Select a valid choice" validation errors when saving a Process that already had private (non-published) sources attached.

### Fix

```python
# ProcessSourceInlineForm.__init__
request = kwargs.pop("request", None)
# …
qs = filter_queryset_for_user(Source.objects.all(), request.user)
# union with already-linked source for safety
if self.instance and self.instance.pk and self.instance.source_id:
    qs = qs | Source.objects.filter(pk=self.instance.source_id)
self.fields["source"].queryset = qs
```

`ProcessSourceInline.get_form_kwargs()` passes `request` into each form. This mirrors the existing autocomplete endpoint pattern (`UserCreatedObjectAutocompleteView` → `filter_queryset_for_user`), so the form-level validation queryset now matches what the user sees in the dropdown.

### Test

`test_update_with_private_source_inline_succeeds` — creates a private source owned by the test user, links it to a process, POSTs an unchanged update form, and asserts a 302 redirect (no validation errors).

All 208 processes tests pass.

## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Verification

- [x] Focused tests or checks were run.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed.
- [x] No secrets, raw data, or production-only configuration are included.

Link to Devin session: https://app.devin.ai/sessions/4e49f2b449564176869b30ea98205e49
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->