### PR TITLE
feat(waste_atlas): add data-conflicts overview navigation

### DIFF
--- a/sources/waste_collection/tests/test_views.py
+++ b/sources/waste_collection/tests/test_views.py
@@ -5178,6 +5178,68 @@ class WasteAtlasMapViewsTestCase(TestCase):
         )
         self.assertContains(response, "Change maps")
 
+    def test_map_overview_links_to_data_conflicts_overview(self):
+        response = self.client.get(reverse("waste-atlas-overview"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            f'href="{reverse("waste-atlas-data-conflicts-overview")}"',
+        )
+        self.assertContains(response, "Data conflicts")
+
+    def test_data_conflicts_overview_renders_for_waste_atlas_group(self):
+        response = self.client.get(reverse("waste-atlas-data-conflicts-overview"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Waste Atlas — Data conflicts")
+        self.assertContains(response, "conflicting catchments")
+
+    def test_data_conflicts_overview_lists_collection_system_maps(self):
+        """The data-conflicts overview surfaces every map whose config opts
+        into the maintainer conflict-overlay aid (currently the
+        collection_system theme across all regional map sets)."""
+        response = self.client.get(reverse("waste-atlas-data-conflicts-overview"))
+
+        self.assertEqual(response.status_code, 200)
+        # Every collection_system map page is listed.
+        self.assertContains(
+            response, reverse("waste-atlas-germany-collection-system-map")
+        )
+        self.assertContains(
+            response, reverse("waste-atlas-catalonia-collection-system-map")
+        )
+        self.assertContains(
+            response, reverse("waste-atlas-italy-collection-system-map")
+        )
+        # A map whose config has no conflict overlay is not listed.
+        self.assertNotContains(response, reverse("waste-atlas-germany-orga-level-map"))
+
+    def test_data_conflicts_overview_links_back_to_map_overview(self):
+        response = self.client.get(reverse("waste-atlas-data-conflicts-overview"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            f'href="{reverse("waste-atlas-overview")}"',
+        )
+        self.assertContains(response, "Map overview")
+
+    def test_data_conflicts_overview_denies_anonymous_users(self):
+        self.client.logout()
+        response = self.client.get(reverse("waste-atlas-data-conflicts-overview"))
+
+        self.assertEqual(response.status_code, 302)
+
+    def test_data_conflicts_overview_denies_users_without_waste_atlas_group(self):
+        non_atlas_user = User.objects.create_user(
+            username="non-atlas-user-conflicts", password="secret"
+        )
+        self.client.force_login(non_atlas_user)
+        response = self.client.get(reverse("waste-atlas-data-conflicts-overview"))
+
+        self.assertEqual(response.status_code, 403)
+
     def test_germany_collection_system_change_map_renders(self):
         response = self.client.get(
             reverse("waste-atlas-change-map", args=["DE", "collection_system"])

--- a/sources/waste_collection/waste_atlas/map_selection.py
+++ b/sources/waste_collection/waste_atlas/map_selection.py
@@ -7,6 +7,7 @@ selector with a consistent label.
 
 from urllib.parse import urlencode
 
+from .map_configs import MAP_CONFIGS
 from .pages import MAP_PAGES, MAP_SET_LABELS
 
 # Short selector label per theme key.
@@ -444,3 +445,33 @@ def build_map_selection_context(
             selected_map_set, selected_theme, themes_by_map_set
         ),
     }
+
+
+def build_conflict_maps_context(reverse_func):
+    """Return context listing every map page whose config opts into the
+    maintainer conflict-overlay aid (``conflictUrl`` in ``MAP_CONFIGS``).
+
+    Each entry carries the page's reverse URL, title, and the label of its
+    map set so the data-conflicts overview can render a plain link list
+    grouped by region.  Pages without a selector set (generic/legacy routes)
+    are skipped.
+    """
+    conflict_maps = []
+    for page in MAP_PAGES:
+        map_set = page["selector_set"]
+        if not map_set:
+            continue
+        config = MAP_CONFIGS.get(page["config_key"], {})
+        if not config.get("conflictUrl"):
+            continue
+        conflict_maps.append(
+            {
+                "url": reverse_func(page["name"]),
+                "title": page["title"],
+                "map_set": map_set,
+                "map_set_label": MAP_SET_LABELS.get(map_set, map_set),
+                "theme_label": THEME_LABELS.get(page["theme"], page["theme"]),
+            }
+        )
+    conflict_maps.sort(key=lambda item: (item["map_set_label"], item["title"]))
+    return {"conflict_maps": conflict_maps}

--- a/sources/waste_collection/waste_atlas/templates/waste_atlas/data_conflicts_overview.html
+++ b/sources/waste_collection/waste_atlas/templates/waste_atlas/data_conflicts_overview.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% load static %}
+{% block title %}
+   Waste Atlas — Data conflicts
+{% endblock title %}
+{% block style_sheets %}
+   <link href="{% static 'css/waste_atlas.min.css' %}" rel="stylesheet">
+{% endblock style_sheets %}
+{% block content %}
+   <div class="container mt-4">
+      <div class="atlas-hero">
+         <div class="atlas-eyebrow">Waste Atlas</div>
+         <h1 class="mb-1">Data conflicts</h1>
+         <p class="lead mb-2">Maps that highlight conflicting catchments.</p>
+         <p class="text-muted">
+            Some waste atlas maps can display only one value per catchment per theme.
+            Where the dataset holds several collections with different theme values for
+            the same catchment, these maps offer a "Highlight conflicting catchments"
+            overlay so data maintainers can see where the single-value assumption breaks
+            down. Open a map below and toggle the overlay to inspect the conflicting
+            catchments.
+         </p>
+      </div>
+      <section class="atlas-panel atlas-directory" aria-labelledby="atlas-conflicts-title">
+         <h2 class="atlas-section-title" id="atlas-conflicts-title">Conflict-overlay maps</h2>
+         {% if conflict_maps %}
+            <div class="atlas-map-list">
+               {% for conflict_map in conflict_maps %}
+                  <a class="atlas-map-link"
+                     href="{{ conflict_map.url }}">{{ conflict_map.map_set_label }} — {{ conflict_map.theme_label }}</a>
+               {% endfor %}
+            </div>
+         {% else %}
+            <p class="text-muted">No maps with a conflict overlay are configured yet.</p>
+         {% endif %}
+      </section>
+      <a class="btn btn-outline-secondary btn-sm"
+         href="{% url 'waste-atlas-overview' %}">
+         <i class="fas fa-th-list"></i> Map overview
+      </a>
+   </div>
+{% endblock content %}

--- a/sources/waste_collection/waste_atlas/templates/waste_atlas/overview.html
+++ b/sources/waste_collection/waste_atlas/templates/waste_atlas/overview.html
@@ -19,6 +19,9 @@
          <a class="atlas-hero-link" href="{% url 'waste-atlas-change-map-overview' %}">
             <i class="fas fa-exchange-alt"></i> Change maps
          </a>
+         <a class="atlas-hero-link" href="{% url 'waste-atlas-data-conflicts-overview' %}">
+            <i class="fas fa-exclamation-triangle"></i> Data conflicts
+         </a>
       </header>
       <section class="atlas-panel atlas-finder" aria-labelledby="atlas-finder-title">
          <h2 class="atlas-section-title" id="atlas-finder-title">Find a map</h2>

--- a/sources/waste_collection/waste_atlas/urls.py
+++ b/sources/waste_collection/waste_atlas/urls.py
@@ -10,6 +10,7 @@ from .views import (
     EuropeDataCoverageMapIframeView,
     EuropeDataCoverageMapView,
     WasteAtlasChangeMapOverviewView,
+    WasteAtlasDataConflictsOverviewView,
     WasteAtlasOverviewView,
 )
 
@@ -24,6 +25,11 @@ urlpatterns = [
         "map/changes/",
         WasteAtlasChangeMapOverviewView.as_view(),
         name="waste-atlas-change-map-overview",
+    ),
+    path(
+        "map/data-conflicts/",
+        WasteAtlasDataConflictsOverviewView.as_view(),
+        name="waste-atlas-data-conflicts-overview",
     ),
     path(
         "map/changes/<str:map_set>/<str:theme>/",

--- a/sources/waste_collection/waste_atlas/views.py
+++ b/sources/waste_collection/waste_atlas/views.py
@@ -7,6 +7,7 @@ from django.views.generic import TemplateView
 
 from .map_selection import (
     MAP_SELECTION_YEARS,
+    build_conflict_maps_context,
     build_map_selection_context,
     build_related_maps_context,
     resolve_map_set,
@@ -189,6 +190,22 @@ class WasteAtlasChangeMapOverviewView(WasteAtlasGroupMixin, TemplateView):
         ctx["default_to_year"] = self.request.GET.get(
             "to_year", years[-1] if years else "2024"
         )
+        return ctx
+
+
+class WasteAtlasDataConflictsOverviewView(WasteAtlasGroupMixin, TemplateView):
+    """Overview page listing maps with the maintainer conflict-overlay aid.
+
+    Surfaces every choropleth map whose ``MAP_CONFIGS`` entry opts into the
+    conflict overlay (``conflictUrl``) so data maintainers can find maps that
+    highlight catchments where the dataset holds conflicting theme values.
+    """
+
+    template_name = "waste_atlas/data_conflicts_overview.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx.update(build_conflict_maps_context(reverse))
         return ctx
 
 


### PR DESCRIPTION
## Summary
- The maintainer conflict-overlay aid (PR #265) was only reachable by opening an individual collection-system map and toggling the overlay. This adds a dedicated **"Data conflicts" overview** page that lists every choropleth map whose config opts into the conflict overlay, plus a hero link on the main Waste Atlas overview (next to "Change maps") so maintainers can find these maps directly.
- New `build_conflict_maps_context()` derives the list from `MAP_PAGES` + `MAP_CONFIGS` (`conflictUrl`), so future conflict-overlay maps appear automatically.
- New `WasteAtlasDataConflictsOverviewView` (`waste_atlas` group gated, mirroring the change-map overview) at `map/data-conflicts/`.
- New `data_conflicts_overview.html` template using the clean unified atlas layout (plain `.atlas-map-link` list, link back to overview).
- Hero link added to `overview.html`.

#### Test plan
- [x] Focused tests (6): hero link, rendering, map listing (incl. negative assertion for a non-conflict map), back-link, anonymous denial (302), non-group denial (403) — all green.
- [x] Nearby tests (82): `WasteAtlasMapViewsTestCase` + `test_waste_atlas_map_configs` — all green.
- [x] `ruff check` and `ruff format --check` clean; pre-commit hooks passed.
- [ ] Manual: log in as a `waste_atlas` user, open the overview, click "Data conflicts", confirm the collection-system maps for each region are listed and the overlay toggle still works on a target map.

Generated with [Devin](https://devin.ai)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/267" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->