### PR TITLE
feat(waste_atlas): update Europe coverage map to final case-study selection

### DIFF
--- a/sources/waste_collection/tests/test_views.py
+++ b/sources/waste_collection/tests/test_views.py
@@ -4983,6 +4983,39 @@ class WasteAtlasMapViewsTestCase(TestCase):
         self.assertContains(response, "WasteAtlasChoropleth.exportElementSVG")
         self.assertContains(response, "WasteAtlasChoropleth.exportElementPNG")
 
+    def test_europe_data_coverage_map_highlights_final_case_study_selection(self):
+        """The coverage map highlights only the final case-study regions."""
+        response = self.client.get(reverse("waste-atlas-europe-data-coverage-map"))
+
+        self.assertEqual(response.status_code, 200)
+        # Sweden is the only highlighted country.
+        self.assertContains(response, "new Set(['SE'])")
+        # German NUTS-1 regions are fetched (replaces the former Belgium fetch).
+        self.assertContains(response, "levl_code=1&cntr_code=DE")
+        # Final sub-national case-study regions.
+        self.assertContains(response, "new Set(['DE1', 'DEA', 'DEB', 'ES51', 'ITH1'])")
+        # Region list reflects the final selection.
+        self.assertContains(response, "Sweden")
+        self.assertContains(response, "Nordrhein-Westfalen")
+        self.assertContains(response, "Rheinland-Pfalz")
+        self.assertContains(response, "Baden-Württemberg")
+        self.assertContains(response, "South Tyrol")
+        self.assertContains(response, "Catalonia")
+        # Subtitle lists the final selection.
+        self.assertContains(
+            response,
+            "Sweden, Nordrhein-Westfalen, Rheinland-Pfalz, "
+            "Baden-Württemberg, South Tyrol, and Catalonia",
+        )
+        # Former case-study entries are no longer present.
+        self.assertNotContains(response, "'DE', 'DK', 'SE', 'NL'")
+        self.assertNotContains(response, "'BE1', 'BE2', 'ES51', 'ITH1'")
+        self.assertNotContains(response, "levl_code=1&cntr_code=BE")
+        self.assertNotContains(response, ">Germany</li>")
+        self.assertNotContains(response, ">Denmark</li>")
+        self.assertNotContains(response, ">Flanders + Brussels</li>")
+        self.assertNotContains(response, ">The Netherlands</li>")
+
     def test_atlas_pages_link_shared_stylesheet(self):
         """Atlas pages load the shared waste_atlas stylesheet instead of inline CSS."""
         for url_name in (

--- a/sources/waste_collection/waste_atlas/templates/waste_atlas/karte0_europe_data_coverage.html
+++ b/sources/waste_collection/waste_atlas/templates/waste_atlas/karte0_europe_data_coverage.html
@@ -94,11 +94,10 @@
         </div>
         <div class="card-body">
           <ul class="coverage-region-list mb-0">
-            <li>Germany</li>
-            <li>Denmark</li>
             <li>Sweden</li>
-            <li>Flanders + Brussels</li>
-            <li>The Netherlands</li>
+            <li>Nordrhein-Westfalen</li>
+            <li>Rheinland-Pfalz</li>
+            <li>Baden-Württemberg</li>
             <li>South Tyrol</li>
             <li>Catalonia</li>
           </ul>
@@ -118,8 +117,8 @@
       var loadingEl = document.getElementById('loading-overlay');
       var btnSVG = document.getElementById('btn-export-svg');
       var btnPNG = document.getElementById('btn-export-png');
-      var highlightedCountries = new Set(['DE', 'DK', 'SE', 'NL']);
-      var highlightedRegions = new Set(['BE1', 'BE2', 'ES51', 'ITH1']);
+      var highlightedCountries = new Set(['SE']);
+      var highlightedRegions = new Set(['DE1', 'DEA', 'DEB', 'ES51', 'ITH1']);
       var highlightFill = '#6dbb5a';
       var neutralFill = '#eceff3';
       var neutralStroke = '#7a8694';
@@ -386,15 +385,15 @@
 
       Promise.all([
         fetchJson('/maps/api/nuts_region/geojson/?levl_code=0'),
-        fetchJson('/maps/api/nuts_region/geojson/?levl_code=1&cntr_code=BE'),
+        fetchJson('/maps/api/nuts_region/geojson/?levl_code=1&cntr_code=DE'),
         fetchJson('/maps/api/nuts_region/geojson/?levl_code=2&cntr_code=ES'),
         fetchJson('/maps/api/nuts_region/geojson/?levl_code=2&cntr_code=IT')
       ]).then(function (results) {
         var countries = trimFeatureCollectionToExtent(results[0]);
-        var belgiumRegions = trimFeatureCollectionToExtent(results[1]);
+        var germanyRegions = trimFeatureCollectionToExtent(results[1]);
         var spainRegions = trimFeatureCollectionToExtent(results[2]);
         var italyRegions = trimFeatureCollectionToExtent(results[3]);
-        var highlightedRegionFeatures = (belgiumRegions.features || []).concat(spainRegions.features || []).concat(italyRegions.features || [])
+        var highlightedRegionFeatures = (germanyRegions.features || []).concat(spainRegions.features || []).concat(italyRegions.features || [])
           .filter(function (feature) {
             var nutsId = feature.properties && feature.properties.nuts_id;
             return highlightedRegions.has(nutsId);
@@ -459,7 +458,7 @@
           .attr('font-family', "'Nunito', sans-serif")
           .attr('font-size', 13)
           .attr('fill', '#5c6670')
-          .text('Germany, Denmark, Sweden, Flanders + Brussels, the Netherlands, South Tyrol, and Catalonia');
+          .text('Sweden, Nordrhein-Westfalen, Rheinland-Pfalz, Baden-Württemberg, South Tyrol, and Catalonia');
 
         drawLegend(svg, width, height);
         loadingEl.style.display = 'none';

--- a/sources/waste_collection/waste_atlas/templates/waste_atlas/karte0_europe_data_coverage_iframe.html
+++ b/sources/waste_collection/waste_atlas/templates/waste_atlas/karte0_europe_data_coverage_iframe.html
@@ -1,9 +1,7 @@
 {% extends "base_iframe.html" %}
-
 {% block title %}
   Waste Atlas — {{ map_title }}
 {% endblock title %}
-
 {% block style_sheets %}
   {{ block.super }}
   <style>
@@ -63,7 +61,6 @@
     }
   </style>
 {% endblock style_sheets %}
-
 {% block content %}
   <div class="coverage-page{% if iframe_mode %} coverage-page--iframe{% endif %}">
     {% if not iframe_mode %}
@@ -71,7 +68,6 @@
       <p class="lead">
         Overview of European countries and regions for which waste collection data is already available in the atlas.
       </p>
-
       <div class="mb-3">
         <a href="{% url 'waste-atlas-overview' %}"
            class="btn btn-outline-secondary btn-sm">
@@ -79,7 +75,6 @@
         </a>
       </div>
     {% endif %}
-
     <div id="map-container">
       <div id="loading-overlay">
         <i class="fas fa-spinner fa-spin me-2"></i> Loading map data…
@@ -87,7 +82,6 @@
       <svg id="europe-coverage-svg">
       </svg>
     </div>
-
     {% if not iframe_mode %}
       <div class="card">
         <div class="card-header">
@@ -95,11 +89,10 @@
         </div>
         <div class="card-body">
           <ul class="coverage-region-list mb-0">
-            <li>Germany</li>
-            <li>Denmark</li>
             <li>Sweden</li>
-            <li>Flanders + Brussels</li>
-            <li>The Netherlands</li>
+            <li>Nordrhein-Westfalen</li>
+            <li>Rheinland-Pfalz</li>
+            <li>Baden-Württemberg</li>
             <li>South Tyrol</li>
             <li>Catalonia</li>
           </ul>
@@ -108,7 +101,6 @@
     {% endif %}
   </div>
 {% endblock content %}
-
 {% block javascript %}
   {{ block.super }}
   <script src="https://cdn.jsdelivr.net/npm/d3@7/dist/d3.min.js"></script>
@@ -117,8 +109,8 @@
       var svgEl = document.getElementById('europe-coverage-svg');
       var mapContainer = document.getElementById('map-container');
       var loadingEl = document.getElementById('loading-overlay');
-      var highlightedCountries = new Set(['DE', 'DK', 'SE', 'NL']);
-      var highlightedRegions = new Set(['BE1', 'BE2', 'ES51', 'ITH1']);
+      var highlightedCountries = new Set(['SE']);
+      var highlightedRegions = new Set(['DE1', 'DEA', 'DEB', 'ES51', 'ITH1']);
       var highlightFill = '#6dbb5a';
       var neutralFill = '#eceff3';
       var neutralStroke = '#7a8694';
@@ -385,15 +377,15 @@
 
       Promise.all([
         fetchJson('/maps/api/nuts_region/geojson/?levl_code=0'),
-        fetchJson('/maps/api/nuts_region/geojson/?levl_code=1&cntr_code=BE'),
+        fetchJson('/maps/api/nuts_region/geojson/?levl_code=1&cntr_code=DE'),
         fetchJson('/maps/api/nuts_region/geojson/?levl_code=2&cntr_code=ES'),
         fetchJson('/maps/api/nuts_region/geojson/?levl_code=2&cntr_code=IT')
       ]).then(function (results) {
         var countries = trimFeatureCollectionToExtent(results[0]);
-        var belgiumRegions = trimFeatureCollectionToExtent(results[1]);
+        var germanyRegions = trimFeatureCollectionToExtent(results[1]);
         var spainRegions = trimFeatureCollectionToExtent(results[2]);
         var italyRegions = trimFeatureCollectionToExtent(results[3]);
-        var highlightedRegionFeatures = (belgiumRegions.features || []).concat(spainRegions.features || []).concat(italyRegions.features || [])
+        var highlightedRegionFeatures = (germanyRegions.features || []).concat(spainRegions.features || []).concat(italyRegions.features || [])
           .filter(function (feature) {
             var nutsId = feature.properties && feature.properties.nuts_id;
             return highlightedRegions.has(nutsId);
@@ -458,7 +450,7 @@
           .attr('font-family', "'Nunito', sans-serif")
           .attr('font-size', 13)
           .attr('fill', '#5c6670')
-          .text('Germany, Denmark, Sweden, Flanders + Brussels, the Netherlands, South Tyrol, and Catalonia');
+          .text('Sweden, Nordrhein-Westfalen, Rheinland-Pfalz, Baden-Württemberg, South Tyrol, and Catalonia');
 
         drawLegend(svg, width, height);
         loadingEl.style.display = 'none';


### PR DESCRIPTION
## Summary

- Replaces the previous case-study regions on the Europe data-coverage map with the final selection: **Sweden, Nordrhein-Westfalen (DEA), Rheinland-Pfalz (DEB), Baden-Württemberg (DE1), South Tyrol (ITH1), and Catalonia (ES51)**
- Updates both the standalone and iframe coverage map templates: highlighted country/region NUTS sets, NUTS fetch (BE NUTS-1 → DE NUTS-1), region list, and subtitle
- Adds a focused test verifying the new selection and that the former entries (Germany, Denmark, Netherlands, Flanders+Brussels) are no longer present

#### Test plan

- [x] New test `test_europe_data_coverage_map_highlights_final_case_study_selection` fails before the template change (red)
- [x] New test passes after the template change (green)
- [x] Full `WasteAtlasMapViewsTestCase` (62 tests) passes
- [x] `ruff check` and `ruff format` pass

Generated with [Devin](https://devin.ai)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->