### PR TITLE
fix(object_management): make review transitions atomic

### DIFF
--- a/docs/05_roadmap/README.md
+++ b/docs/05_roadmap/README.md
@@ -108,6 +108,7 @@ on it.
    call `save()` without `update_fields`. Implement compare-and-swap transitions
    (`filter(pk, publication_status=expected).update(...)` inside a transaction, or
    `select_for_update`), saving only workflow fields. Add transition tests.
+   **Status:** completed in PR #273.
 2. **Single source of truth for permissions.** Permission logic is spread over
    `permissions.py` (object permission, submit/approve checks, `get_object_policy`),
    view mixins, and viewsets with double `check_object_permissions` calls. Consolidate
@@ -299,7 +300,7 @@ consolidation that pays compounding dividends.
 1. Waste Atlas publication scoping fix + regression test (WS3.1)
 2. CI workflow running the full suite + ruff (WS6.1)
 3. Settings hardening checklist (WS7)
-4. Atomic review-state transitions (WS2.1)
+4. Atomic review-state transitions (WS2.1) — completed in PR #273
 
 **Phase 1 — Foundation inversion (next, ~1 month)**
 5. Object-management hooks; strip waste_collection out of utils (WS1-A)
@@ -352,4 +353,4 @@ decoupling), #87 (soilcom cleanup), #139/#141/#145 (GeoJSON/serialization
 performance & cache warmup), #142 (collector NOT NULL), #143 (normalization bug),
 #106 (legacy unit field).
 
-_Last updated: 2026-06-23_
+_Last updated: 2026-07-11_

--- a/materials/tests/test_models.py
+++ b/materials/tests/test_models.py
@@ -391,12 +391,12 @@ class SampleSeriesTestCase(TestCase):
     def test_approve_allows_series_with_samples(self):
         """Test that approve() works when series has samples."""
         series_with_sample = SampleSeries.objects.create(material=self.material1)
-        series_with_sample.publication_status = SampleSeries.STATUS_REVIEW
         Sample.objects.create(
             material=self.material1,
             series=series_with_sample,
             timestep=Timestep.objects.default(),
         )
+        series_with_sample.submit_for_review()
 
         # Should not raise any exception and should approve the series
         try:

--- a/sources/waste_collection/tests/test_views.py
+++ b/sources/waste_collection/tests/test_views.py
@@ -4393,7 +4393,10 @@ class WasteAtlasMapViewsTestCase(TestCase):
         self.assertContains(response, 'id="atlas-region-tabs"')
 
     def test_change_map_overview_and_conflicts_render_shell_tree(self):
-        for route in ("waste-atlas-change-map-overview", "waste-atlas-data-conflicts-overview"):
+        for route in (
+            "waste-atlas-change-map-overview",
+            "waste-atlas-data-conflicts-overview",
+        ):
             with self.subTest(route=route):
                 response = self.client.get(reverse(route))
                 self.assertEqual(response.status_code, 200)
@@ -4546,9 +4549,7 @@ class WasteAtlasMapViewsTestCase(TestCase):
         self.assertContains(response, "Map overview")
 
     def test_detail_page_actions_live_in_hero_actions(self):
-        response = self.client.get(
-            reverse("waste-atlas-germany-collection-system-map")
-        )
+        response = self.client.get(reverse("waste-atlas-germany-collection-system-map"))
         self.assertEqual(response.status_code, 200)
         # The map navigation actions share one context-header row (and the
         # Feedback link sits in the shared shell toolbar) so the buttons sit in

--- a/utils/object_management/models.py
+++ b/utils/object_management/models.py
@@ -216,22 +216,13 @@ class UserCreatedObject(CRUDUrlsMixin, CommonInfo):
         ]
 
     def _lock_and_validate_transition(self, expected_statuses, error_message):
-        current_state = (
+        current_status = (
             self.__class__._default_manager.select_for_update()
             .filter(pk=self.pk)
-            .values_list("publication_status", "lastmodified_at")
+            .values_list("publication_status", flat=True)
             .first()
         )
-        if current_state is None:
-            raise ValidationError(error_message)
-
-        current_status, current_lastmodified_at = current_state
-        has_current_status = current_status in expected_statuses
-        has_unsaved_status = (
-            self.publication_status in expected_statuses
-            and self.lastmodified_at == current_lastmodified_at
-        )
-        if not has_current_status and not has_unsaved_status:
+        if current_status not in expected_statuses:
             raise ValidationError(error_message)
 
     def submit_for_review(self):

--- a/utils/object_management/models.py
+++ b/utils/object_management/models.py
@@ -4,8 +4,9 @@ from django.contrib.auth.models import User
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Q
+from django.utils import timezone
 from django.utils.functional import cached_property
 
 from ..models import CRUDUrlsMixin
@@ -214,22 +215,47 @@ class UserCreatedObject(CRUDUrlsMixin, CommonInfo):
             models.Index(fields=["publication_status"]),
         ]
 
+    def _lock_and_validate_transition(self, expected_statuses, error_message):
+        current_state = (
+            self.__class__._default_manager.select_for_update()
+            .filter(pk=self.pk)
+            .values_list("publication_status", "lastmodified_at")
+            .first()
+        )
+        if current_state is None:
+            raise ValidationError(error_message)
+
+        current_status, current_lastmodified_at = current_state
+        has_current_status = current_status in expected_statuses
+        has_unsaved_status = (
+            self.publication_status in expected_statuses
+            and self.lastmodified_at == current_lastmodified_at
+        )
+        if not has_current_status and not has_unsaved_status:
+            raise ValidationError(error_message)
+
     def submit_for_review(self):
         """
         Submit this object for review. Transitions from private to review status.
         Sets submitted_at timestamp and clears approval fields if previously set.
         """
-        if self.publication_status not in (self.STATUS_PRIVATE, self.STATUS_DECLINED):
-            raise ValidationError(
-                "Only private or declined objects can be submitted for review."
+        with transaction.atomic():
+            self._lock_and_validate_transition(
+                (self.STATUS_PRIVATE, self.STATUS_DECLINED),
+                "Only private or declined objects can be submitted for review.",
             )
-        self.publication_status = self.STATUS_REVIEW
-        from django.utils import timezone
-
-        self.submitted_at = timezone.now()
-        self.approved_at = None
-        self.approved_by = None
-        self.save()
+            self.publication_status = self.STATUS_REVIEW
+            self.submitted_at = timezone.now()
+            self.approved_at = None
+            self.approved_by = None
+            self.save(
+                update_fields=[
+                    "publication_status",
+                    "submitted_at",
+                    "approved_at",
+                    "approved_by",
+                ]
+            )
         # TODO: Implement notification to moderators
         return True
 
@@ -238,13 +264,14 @@ class UserCreatedObject(CRUDUrlsMixin, CommonInfo):
         return self.submit_for_review()
 
     def withdraw_from_review(self):
-        if self.publication_status not in (self.STATUS_REVIEW, self.STATUS_DECLINED):
-            raise ValidationError(
-                "Only objects in review or declined can be withdrawn to private."
+        with transaction.atomic():
+            self._lock_and_validate_transition(
+                (self.STATUS_REVIEW, self.STATUS_DECLINED),
+                "Only objects in review or declined can be withdrawn to private.",
             )
-        self.publication_status = self.STATUS_PRIVATE
-        self.submitted_at = None
-        self.save()
+            self.publication_status = self.STATUS_PRIVATE
+            self.submitted_at = None
+            self.save(update_fields=["publication_status", "submitted_at"])
         # TODO: Implement notification to moderators
 
     def approve(self, user=None):
@@ -252,32 +279,45 @@ class UserCreatedObject(CRUDUrlsMixin, CommonInfo):
         Approve this object, transitioning from review to published.
         Sets approved_at and approved_by.
         """
-        if self.publication_status != self.STATUS_REVIEW:
-            raise ValidationError("Only objects in review can be approved.")
-        self.publication_status = self.STATUS_PUBLISHED
-        from django.utils import timezone
-
-        self.approved_at = timezone.now()
-        if user is not None:
-            self.approved_by = user
-        self.save()
+        with transaction.atomic():
+            self._lock_and_validate_transition(
+                (self.STATUS_REVIEW,), "Only objects in review can be approved."
+            )
+            self.publication_status = self.STATUS_PUBLISHED
+            self.approved_at = timezone.now()
+            update_fields = ["publication_status", "approved_at"]
+            if user is not None:
+                self.approved_by = user
+                update_fields.append("approved_by")
+            self.save(update_fields=update_fields)
         # TODO: Implement notification to the owner
 
     def reject(self):
-        if self.publication_status != self.STATUS_REVIEW:
-            raise ValidationError("Only objects in review can be rejected.")
-        self.publication_status = self.STATUS_DECLINED
-        self.submitted_at = None
-        self.approved_at = None
-        self.approved_by = None
-        self.save()
+        with transaction.atomic():
+            self._lock_and_validate_transition(
+                (self.STATUS_REVIEW,), "Only objects in review can be rejected."
+            )
+            self.publication_status = self.STATUS_DECLINED
+            self.submitted_at = None
+            self.approved_at = None
+            self.approved_by = None
+            self.save(
+                update_fields=[
+                    "publication_status",
+                    "submitted_at",
+                    "approved_at",
+                    "approved_by",
+                ]
+            )
         # TODO: Implement notification to the owner
 
     def archive(self):
-        if self.publication_status != self.STATUS_PUBLISHED:
-            raise ValidationError("Only published objects can be archived.")
-        self.publication_status = self.STATUS_ARCHIVED
-        self.save()
+        with transaction.atomic():
+            self._lock_and_validate_transition(
+                (self.STATUS_PUBLISHED,), "Only published objects can be archived."
+            )
+            self.publication_status = self.STATUS_ARCHIVED
+            self.save(update_fields=["publication_status"])
         # TODO: Implement notification to the owner
 
     @property

--- a/utils/object_management/tests/test_models.py
+++ b/utils/object_management/tests/test_models.py
@@ -138,6 +138,25 @@ class ReviewWorkflowModelTests(TestCase):
             self.collection.publication_status, UserCreatedObject.STATUS_PRIVATE
         )
 
+    def test_stale_review_object_cannot_bypass_a_direct_status_change(self):
+        self.collection.publication_status = UserCreatedObject.STATUS_REVIEW
+        self.collection.save()
+        stale_collection = Collection.objects.get(pk=self.collection.pk)
+
+        Collection.objects.filter(pk=self.collection.pk).update(
+            publication_status=UserCreatedObject.STATUS_PRIVATE
+        )
+
+        with self.assertRaisesMessage(
+            ValidationError, "Only objects in review can be approved."
+        ):
+            stale_collection.approve(user=self.moderator)
+
+        self.collection.refresh_from_db()
+        self.assertEqual(
+            self.collection.publication_status, UserCreatedObject.STATUS_PRIVATE
+        )
+
     def test_submit_for_review_preserves_a_concurrent_content_edit(self):
         stale_collection = Collection.objects.get(pk=self.collection.pk)
         Collection.objects.filter(pk=self.collection.pk).update(

--- a/utils/object_management/tests/test_models.py
+++ b/utils/object_management/tests/test_models.py
@@ -2,6 +2,7 @@ import datetime
 
 from django.contrib.auth.models import Permission, User
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils import timezone
 
@@ -119,6 +120,37 @@ class ReviewWorkflowModelTests(TestCase):
             self.collection.publication_status, UserCreatedObject.STATUS_PRIVATE
         )
         self.assertIsNone(self.collection.submitted_at)
+
+    def test_stale_review_object_cannot_overwrite_a_concurrent_withdrawal(self):
+        self.collection.submit_for_review()
+        stale_collection = Collection.objects.get(pk=self.collection.pk)
+
+        concurrent_collection = Collection.objects.get(pk=self.collection.pk)
+        concurrent_collection.withdraw_from_review()
+
+        with self.assertRaisesMessage(
+            ValidationError, "Only objects in review can be approved."
+        ):
+            stale_collection.approve(user=self.moderator)
+
+        self.collection.refresh_from_db()
+        self.assertEqual(
+            self.collection.publication_status, UserCreatedObject.STATUS_PRIVATE
+        )
+
+    def test_submit_for_review_preserves_a_concurrent_content_edit(self):
+        stale_collection = Collection.objects.get(pk=self.collection.pk)
+        Collection.objects.filter(pk=self.collection.pk).update(
+            description="Concurrent edit"
+        )
+
+        stale_collection.submit_for_review()
+
+        self.collection.refresh_from_db()
+        self.assertEqual(self.collection.description, "Concurrent edit")
+        self.assertEqual(
+            self.collection.publication_status, UserCreatedObject.STATUS_REVIEW
+        )
 
     def test_has_review_feedback_only_reflects_current_submission_cycle(self):
         self.assertFalse(self.collection.has_review_feedback)


### PR DESCRIPTION
## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

Closes #164.

`UserCreatedObject` workflow transitions now run inside `transaction.atomic()`, lock the persisted row, and require the locked database status to permit the transition. Each transition saves only its workflow fields, preventing stale instances from overwriting either concurrent workflow changes or unrelated content edits.

Regression coverage exercises approve-vs-withdraw races through both workflow methods and direct database status updates, plus concurrent content preservation. The SampleSeries approval test now enters review through the persisted workflow before approval.

## Verification

- [x] Focused tests or checks were run.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed. (Not applicable.)
- [x] No secrets, raw data, or production-only configuration are included.

Commands:

```text
/home/ubuntu/BRIT-ops/scripts/brit-worktree-test /home/ubuntu/repos/BRIT -- utils.object_management.tests materials.tests.test_models sources.waste_collection.tests.test_models
/home/ubuntu/BRIT-ops/scripts/brit-worktree-compose /home/ubuntu/repos/BRIT run --rm --no-deps web ruff check .
/home/ubuntu/BRIT-ops/scripts/brit-worktree-compose /home/ubuntu/repos/BRIT run --rm --no-deps web ruff format --check .
```

All 321 targeted tests pass; repository-wide Ruff lint and format checks pass.

Link to Devin session: https://app.devin.ai/sessions/6aa9cba393f44e288f5bf307fac2d262
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->