### PR TITLE
fix(settings): verify production Redis TLS

### DIFF
--- a/brit/settings/heroku.py
+++ b/brit/settings/heroku.py
@@ -1,6 +1,9 @@
+import ssl
+
 import dj_database_url
 
 from .settings import *
+from .settings import _redis_ssl_settings
 
 SITE_ID = 2
 
@@ -8,6 +11,8 @@ DEBUG = False
 
 SECRET_KEY = os.environ.get("SECRET_KEY")
 ALLOWED_HOSTS = list(os.environ.get("ALLOWED_HOSTS", "").split(","))
+CELERY_BROKER_USE_SSL = _redis_ssl_settings(REDIS_URL, ssl.CERT_REQUIRED)
+CELERY_REDIS_BACKEND_USE_SSL = _redis_ssl_settings(REDIS_URL, ssl.CERT_REQUIRED)
 
 # Security settings
 SECURE_SSL_REDIRECT = True

--- a/brit/settings/settings.py
+++ b/brit/settings/settings.py
@@ -173,9 +173,9 @@ def _redis_connection_pool_kwargs(redis_url):
     return {}
 
 
-def _redis_ssl_settings(redis_url):
+def _redis_ssl_settings(redis_url, certificate_requirement=ssl.CERT_NONE):
     if redis_url and urlparse(redis_url).scheme == "rediss":
-        return {"ssl_cert_reqs": ssl.CERT_NONE}
+        return {"ssl_cert_reqs": certificate_requirement}
     return None
 
 

--- a/brit/tests/test_settings.py
+++ b/brit/tests/test_settings.py
@@ -1,3 +1,4 @@
+import os
 import ssl
 import subprocess
 import sys
@@ -51,3 +52,28 @@ class RedisSettingsTests(SimpleTestCase):
             _redis_ssl_settings("rediss://localhost:6379/0"),
             {"ssl_cert_reqs": ssl.CERT_NONE},
         )
+
+
+class ProductionRedisSettingsTests(SimpleTestCase):
+    def test_tls_redis_requires_certificate_verification(self):
+        environment = os.environ.copy()
+        environment["REDIS_URL"] = "rediss://localhost:6379/0"
+        environment["SECRET_KEY"] = "test-secret-key"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import ssl; import brit.settings.heroku as h; "
+                    "expected = {'ssl_cert_reqs': ssl.CERT_REQUIRED}; "
+                    "assert h.CELERY_BROKER_USE_SSL == expected; "
+                    "assert h.CELERY_REDIS_BACKEND_USE_SSL == expected"
+                ),
+            ],
+            capture_output=True,
+            check=False,
+            env=environment,
+            text=True,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)


### PR DESCRIPTION
## Summary

Continue WS7 / #166 by separating local Redis TLS compatibility from the production security policy:

```python
_redis_ssl_settings(url, certificate_requirement=ssl.CERT_NONE)

# brit.settings.heroku
CELERY_*_USE_SSL = _redis_ssl_settings(REDIS_URL, ssl.CERT_REQUIRED)
```

Local and test configurations keep their existing behavior, while the Heroku settings require certificate verification for both the Celery broker and result backend. A fresh-process production-settings regression test covers both values.

Refs #166.

## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Verification

- [x] Focused tests or checks were run: `brit.tests.test_settings` (5 passed), `ruff check .`, `ruff format --check .`, `manage.py check`, and `makemigrations --check --dry-run`.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed (not applicable).
- [x] No secrets, raw data, or production-only configuration are included.

Link to Devin session: https://app.devin.ai/sessions/6aa9cba393f44e288f5bf307fac2d262
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->