### PR TITLE
fix(settings): log ignored Redis failures

### DIFF
--- a/brit/settings/heroku.py
+++ b/brit/settings/heroku.py
@@ -53,6 +53,9 @@ STORAGES = {
 
 # Logging settings
 # In production all logs of unhandled exceptions are mailed to the admins.
+DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS = True
+DJANGO_REDIS_LOGGER = "django_redis"
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -83,6 +86,11 @@ LOGGING = {
         "brit": {
             "handlers": ["console", "mail_admins"],
             "level": "WARNING",
+            "propagate": False,
+        },
+        "django_redis": {
+            "handlers": ["console"],
+            "level": "ERROR",
             "propagate": False,
         },
     },

--- a/brit/tests/test_cache_settings.py
+++ b/brit/tests/test_cache_settings.py
@@ -1,0 +1,64 @@
+import os
+import subprocess
+import sys
+
+from django.test import SimpleTestCase
+
+
+class ProductionCacheLoggingSettingsTests(SimpleTestCase):
+    def run_production_script(self, script):
+        environment = os.environ.copy()
+        environment["DJANGO_SETTINGS_MODULE"] = "brit.settings.heroku"
+        environment["REDIS_URL"] = "redis://localhost:6379/0"
+        environment["SECRET_KEY"] = "test-secret-key"
+        return subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                script,
+            ],
+            capture_output=True,
+            check=False,
+            env=environment,
+            text=True,
+        )
+
+    def test_ignored_redis_exceptions_are_logged(self):
+        completed = self.run_production_script(
+            "import brit.settings.heroku as h; "
+            "assert all("
+            "cache['OPTIONS']['IGNORE_EXCEPTIONS'] "
+            "for cache in h.CACHES.values()"
+            "); "
+            "assert h.DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS is True; "
+            "assert h.DJANGO_REDIS_LOGGER == 'django_redis'; "
+            "assert h.LOGGING['loggers']['django_redis'] == {"
+            "'handlers': ['console'], "
+            "'level': 'ERROR', "
+            "'propagate': False"
+            "}"
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+    def test_ignored_connection_error_is_emitted_to_production_log(self):
+        completed = self.run_production_script(
+            """
+import django
+django.setup()
+from django.core.cache import caches
+from django_redis.exceptions import ConnectionInterrupted
+from unittest.mock import Mock
+
+cache = caches["default"]
+client = Mock()
+error = ConnectionInterrupted(None)
+error.__cause__ = ConnectionError("redis unavailable")
+client.get.side_effect = error
+cache._client = client
+assert cache.get("key") is None
+"""
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("Exception ignored", completed.stderr)


### PR DESCRIPTION
## Summary

Continue WS7 / #166 without changing cache availability behavior:

```python
IGNORE_EXCEPTIONS = True
DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS = True
DJANGO_REDIS_LOGGER = "django_redis"
```

Production now routes ignored `django-redis` connection failures to the console at `ERROR`, where operational log collection can observe them. Fresh-process regression coverage verifies both the production configuration and an actual swallowed `ConnectionInterrupted`: the cache still returns its fallback while emitting `Exception ignored`.

Refs #166.

## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Verification

- [x] Focused tests or checks were run: `brit.tests.test_cache_settings brit.tests.test_settings` (6 passed), `ruff check .`, `ruff format --check .`, `manage.py check`, and `makemigrations --check --dry-run`.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed (not applicable).
- [x] No secrets, raw data, or production-only configuration are included.

Link to Devin session: https://app.devin.ai/sessions/6aa9cba393f44e288f5bf307fac2d262
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->