### PR TITLE
fix(settings): add production CSP report-only baseline

### DIFF
--- a/brit/settings/heroku.py
+++ b/brit/settings/heroku.py
@@ -1,4 +1,5 @@
 import dj_database_url
+from django.utils.csp import CSP
 
 from .settings import *
 
@@ -18,9 +19,18 @@ SECURE_HSTS_SECONDS = 31536000  # 1 year
 SECURE_HSTS_INCLUDE_SUBDOMAINS = True
 SECURE_HSTS_PRELOAD = True
 
+MIDDLEWARE.insert(1, "django.middleware.csp.ContentSecurityPolicyMiddleware")
+
 # Add middleware for emails with logs about unhandled exceptions
 # This middleware is added only in production because it triggers too many logging events during testing in development.
 MIDDLEWARE.append("brit.middleware.ExceptionLoggingMiddleware")
+
+SECURE_CSP_REPORT_ONLY = {
+    "default-src": [CSP.SELF],
+    "base-uri": [CSP.SELF],
+    "frame-ancestors": [CSP.SELF],
+    "object-src": [CSP.NONE],
+}
 
 # Database configuration
 DATABASES["default"] = dj_database_url.config(conn_max_age=600, ssl_require=True)

--- a/brit/tests/test_security_settings.py
+++ b/brit/tests/test_security_settings.py
@@ -1,0 +1,45 @@
+import os
+import subprocess
+import sys
+
+from django.test import SimpleTestCase
+
+
+class ProductionContentSecurityPolicyTests(SimpleTestCase):
+    def test_report_only_policy_is_added_to_responses(self):
+        environment = os.environ.copy()
+        environment["DJANGO_SETTINGS_MODULE"] = "brit.settings.heroku"
+        environment["SECRET_KEY"] = "test-secret-key"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                """
+import django
+django.setup()
+import brit.settings.heroku as h
+from django.http import HttpResponse
+from django.middleware.csp import ContentSecurityPolicyMiddleware
+from django.test import RequestFactory
+
+middleware_path = "django.middleware.csp.ContentSecurityPolicyMiddleware"
+assert middleware_path in h.MIDDLEWARE
+middleware = ContentSecurityPolicyMiddleware(lambda request: HttpResponse("ok"))
+response = middleware(RequestFactory().get("/"))
+expected = (
+    "default-src 'self'; "
+    "base-uri 'self'; "
+    "frame-ancestors 'self'; "
+    "object-src 'none'"
+)
+assert response.headers["Content-Security-Policy-Report-Only"] == expected
+assert "Content-Security-Policy" not in response.headers
+""",
+            ],
+            capture_output=True,
+            check=False,
+            env=environment,
+            text=True,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)


### PR DESCRIPTION
## Summary

Continue WS7 / #166 with Django 6's built-in Content Security Policy support, avoiding a new dependency:

```python
SECURE_CSP_REPORT_ONLY = {
    "default-src": [CSP.SELF],
    "base-uri": [CSP.SELF],
    "frame-ancestors": [CSP.SELF],
    "object-src": [CSP.NONE],
}
```

Production responses now receive `Content-Security-Policy-Report-Only`, while no enforcing `Content-Security-Policy` header is emitted. This exposes the existing inline/external asset violations for the later nonce/asset migration without breaking current pages. A fresh-process regression test exercises the real Django CSP middleware and exact response header.

Refs #166.

## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Verification

- [x] Focused tests or checks were run: `brit.tests.test_security_settings brit.tests.test_settings` (5 passed), `ruff check .`, `ruff format --check .`, `manage.py check`, and `makemigrations --check --dry-run`.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed (not applicable).
- [x] No secrets, raw data, or production-only configuration are included.

Link to Devin session: https://app.devin.ai/sessions/6aa9cba393f44e288f5bf307fac2d262
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->