### PR TITLE
fix(settings): add production error monitoring

### DIFF
--- a/brit/settings/heroku.py
+++ b/brit/settings/heroku.py
@@ -1,10 +1,21 @@
 import dj_database_url
+import sentry_sdk
+from sentry_sdk.integrations.celery import CeleryIntegration
+from sentry_sdk.integrations.django import DjangoIntegration
 
 from .settings import *
 
 SITE_ID = 2
 
 DEBUG = False
+
+SENTRY_DSN = os.environ.get("SENTRY_DSN")
+if SENTRY_DSN:
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        integrations=[DjangoIntegration(), CeleryIntegration()],
+        send_default_pii=False,
+    )
 
 SECRET_KEY = os.environ.get("SECRET_KEY")
 ALLOWED_HOSTS = list(os.environ.get("ALLOWED_HOSTS", "").split(","))

--- a/brit/tests/test_monitoring_settings.py
+++ b/brit/tests/test_monitoring_settings.py
@@ -1,0 +1,80 @@
+import os
+import subprocess
+import sys
+
+from django.test import SimpleTestCase
+
+FAKE_SENTRY_SETUP = """
+import sys
+import types
+
+calls = []
+
+class FakeDjangoIntegration:
+    pass
+
+class FakeCeleryIntegration:
+    pass
+
+sentry_sdk = types.ModuleType("sentry_sdk")
+sentry_sdk.__path__ = []
+sentry_sdk.init = lambda **kwargs: calls.append(kwargs)
+integrations = types.ModuleType("sentry_sdk.integrations")
+integrations.__path__ = []
+django_integration = types.ModuleType("sentry_sdk.integrations.django")
+django_integration.DjangoIntegration = FakeDjangoIntegration
+celery_integration = types.ModuleType("sentry_sdk.integrations.celery")
+celery_integration.CeleryIntegration = FakeCeleryIntegration
+sys.modules["sentry_sdk"] = sentry_sdk
+sys.modules["sentry_sdk.integrations"] = integrations
+sys.modules["sentry_sdk.integrations.django"] = django_integration
+sys.modules["sentry_sdk.integrations.celery"] = celery_integration
+"""
+
+
+class ProductionMonitoringSettingsTests(SimpleTestCase):
+    def run_production_script(self, script, sentry_dsn=None):
+        environment = os.environ.copy()
+        environment["DJANGO_SETTINGS_MODULE"] = "brit.settings.heroku"
+        environment["SECRET_KEY"] = "test-secret-key"
+        if sentry_dsn is None:
+            environment.pop("SENTRY_DSN", None)
+        else:
+            environment["SENTRY_DSN"] = sentry_dsn
+        return subprocess.run(
+            [sys.executable, "-c", FAKE_SENTRY_SETUP + script],
+            capture_output=True,
+            check=False,
+            env=environment,
+            text=True,
+        )
+
+    def test_sentry_initializes_django_and_celery_integrations(self):
+        completed = self.run_production_script(
+            """
+import brit.settings.heroku
+
+assert len(calls) == 1
+options = calls[0]
+assert options["dsn"] == "https://public@example.com/1"
+assert options["send_default_pii"] is False
+assert [type(integration).__name__ for integration in options["integrations"]] == [
+    "FakeDjangoIntegration",
+    "FakeCeleryIntegration",
+]
+""",
+            sentry_dsn="https://public@example.com/1",
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+    def test_sentry_stays_disabled_without_dsn(self):
+        completed = self.run_production_script(
+            """
+import brit.settings.heroku
+
+assert calls == []
+"""
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "psycopg2-binary>=2.9.12",
     # Task queue
     "celery>=5.6.3",
+    # Error monitoring
+    "sentry-sdk==2.64.0",
     # UI and forms
     "django-crispy-forms>=2.6",
     "crispy-bootstrap5>=2026.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 
 [[package]]
@@ -144,6 +144,7 @@ dependencies = [
     { name = "pint" },
     { name = "psycopg2-binary" },
     { name = "requests" },
+    { name = "sentry-sdk" },
     { name = "whitenoise" },
     { name = "xlsxwriter" },
 ]
@@ -193,6 +194,7 @@ requires-dist = [
     { name = "pint", specifier = ">=0.25.3" },
     { name = "psycopg2-binary", specifier = ">=2.9.12" },
     { name = "requests", specifier = ">=2.34.0" },
+    { name = "sentry-sdk", specifier = "==2.64.0" },
     { name = "whitenoise", specifier = ">=6.12.0" },
     { name = "xlsxwriter", specifier = ">=3.2.9" },
 ]
@@ -1709,6 +1711,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337, upload-time = "2026-04-29T22:07:36.33Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811, upload-time = "2026-04-29T22:07:34.966Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.64.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/31/b7341f156a5f6f36f0b4845d6f1c28a2ae4799171dba7007f3a1e9b234b4/sentry_sdk-2.64.0.tar.gz", hash = "sha256:68be2c29e14ae310f8a39e1a79916b6d85c6cb41dcce789d14ff05fe293e4c55", size = 921020, upload-time = "2026-06-30T08:13:47.682Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/a8/3fb9a4319efa3b26f5be0e90e6d8918df43fa7c7e977d26390f589501d82/sentry_sdk-2.64.0-py3-none-any.whl", hash = "sha256:715ea91ca860a819e8d8a50a7bde3a80d0df3b4ed7b6660a20fb9a2d084188f1", size = 498901, upload-time = "2026-06-30T08:13:45.566Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Continue WS7 / #166 by initializing Sentry from production settings only when `SENTRY_DSN` is configured:

```python
if SENTRY_DSN:
    sentry_sdk.init(
        dsn=SENTRY_DSN,
        integrations=[DjangoIntegration(), CeleryIntegration()],
        send_default_pii=False,
    )
```

This loads monitoring during both Django web and Celery worker startup, explicitly enables both integrations, and keeps deployments without a DSN unchanged. The SDK is pinned to `2.64.0`; fresh-process tests verify initialization options and the no-DSN path without sending events.

Refs #166.

## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Verification

- [x] Focused tests or checks were run: `brit.tests.test_monitoring_settings brit.tests.test_settings` (6 passed), `ruff check .`, `ruff format --check .`, `uv lock --check`, `manage.py check`, and `makemigrations --check --dry-run`.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed (not applicable).
- [x] No secrets, raw data, or production-only configuration are included.

Link to Devin session: https://app.devin.ai/sessions/6aa9cba393f44e288f5bf307fac2d262
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->