### PR TITLE
fix(settings): require production secret key

### DIFF
--- a/brit/settings/heroku.py
+++ b/brit/settings/heroku.py
@@ -1,8 +1,8 @@
 import ssl
 
 import dj_database_url
-from django.core.exceptions import ImproperlyConfigured
 import sentry_sdk
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.csp import CSP
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration

--- a/brit/settings/heroku.py
+++ b/brit/settings/heroku.py
@@ -1,6 +1,7 @@
 import ssl
 
 import dj_database_url
+from django.core.exceptions import ImproperlyConfigured
 import sentry_sdk
 from django.utils.csp import CSP
 from sentry_sdk.integrations.celery import CeleryIntegration
@@ -22,6 +23,9 @@ if SENTRY_DSN:
     )
 
 SECRET_KEY = os.environ.get("SECRET_KEY")
+if not SECRET_KEY:
+    raise ImproperlyConfigured("SECRET_KEY must be set in production.")
+
 ALLOWED_HOSTS = list(os.environ.get("ALLOWED_HOSTS", "").split(","))
 CELERY_BROKER_USE_SSL = _redis_ssl_settings(REDIS_URL, ssl.CERT_REQUIRED)
 CELERY_REDIS_BACKEND_USE_SSL = _redis_ssl_settings(REDIS_URL, ssl.CERT_REQUIRED)

--- a/brit/tests/test_production_settings.py
+++ b/brit/tests/test_production_settings.py
@@ -1,0 +1,48 @@
+import os
+import subprocess
+import sys
+
+from django.test import SimpleTestCase
+
+
+class ProductionSecretKeyTests(SimpleTestCase):
+    def test_configured_secret_key_imports_production_settings(self):
+        environment = os.environ.copy()
+        environment["DJANGO_SETTINGS_MODULE"] = "brit.settings.heroku"
+        environment["SECRET_KEY"] = "configured-secret-key"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import brit.settings.heroku as production_settings; "
+                    "assert production_settings.SECRET_KEY == "
+                    "'configured-secret-key'"
+                ),
+            ],
+            capture_output=True,
+            check=False,
+            env=environment,
+            text=True,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+    def test_missing_secret_key_fails_settings_import(self):
+        environment = os.environ.copy()
+        environment["DJANGO_SETTINGS_MODULE"] = "brit.settings.heroku"
+        environment.pop("SECRET_KEY", None)
+        completed = subprocess.run(
+            [sys.executable, "-c", "import brit.settings.heroku"],
+            capture_output=True,
+            check=False,
+            env=environment,
+            text=True,
+        )
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn(
+            "django.core.exceptions.ImproperlyConfigured: "
+            "SECRET_KEY must be set in production.",
+            completed.stderr,
+        )


### PR DESCRIPTION
## Summary

Production settings now fail fast with `ImproperlyConfigured("SECRET_KEY must be set in production.")` when `SECRET_KEY` is missing or empty. Fresh-process tests cover both the configured-key and missing-key cases so settings import behavior is verified without leaking process state.

Refs #166

## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [ ] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [ ] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Verification

- [x] Focused tests or checks were run: `brit.tests.test_production_settings brit.tests.test_settings` (6 passed); Ruff check/format, `uv lock` check, Django system check, and migration check all passed.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed. Not applicable; no assets changed.
- [x] No secrets, raw data, or production-only configuration are included.

Link to Devin session: https://app.devin.ai/sessions/1472f81770a04c10b26a2d35c99f8146
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->