### PR TITLE
fix(settings): allow self-signed Redis certs on Heroku Celery SSL

### DIFF
--- a/brit/settings/heroku.py
+++ b/brit/settings/heroku.py
@@ -23,8 +23,10 @@ if SENTRY_DSN:
 
 SECRET_KEY = os.environ.get("SECRET_KEY")
 ALLOWED_HOSTS = list(os.environ.get("ALLOWED_HOSTS", "").split(","))
-CELERY_BROKER_USE_SSL = _redis_ssl_settings(REDIS_URL, ssl.CERT_REQUIRED)
-CELERY_REDIS_BACKEND_USE_SSL = _redis_ssl_settings(REDIS_URL, ssl.CERT_REQUIRED)
+# Heroku Redis uses self-signed certificates, so certificate verification
+# must be disabled for TLS connections.
+CELERY_BROKER_USE_SSL = _redis_ssl_settings(REDIS_URL, ssl.CERT_NONE)
+CELERY_REDIS_BACKEND_USE_SSL = _redis_ssl_settings(REDIS_URL, ssl.CERT_NONE)
 
 # Security settings
 SECURE_SSL_REDIRECT = True

--- a/brit/tests/test_settings.py
+++ b/brit/tests/test_settings.py
@@ -97,7 +97,7 @@ class RedisSettingsTests(SimpleTestCase):
 
 
 class ProductionRedisSettingsTests(SimpleTestCase):
-    def test_tls_redis_requires_certificate_verification(self):
+    def test_tls_redis_accepts_self_signed_certificates(self):
         environment = os.environ.copy()
         environment["REDIS_URL"] = "rediss://localhost:6379/0"
         environment["SECRET_KEY"] = "test-secret-key"
@@ -107,7 +107,7 @@ class ProductionRedisSettingsTests(SimpleTestCase):
                 "-c",
                 (
                     "import ssl; import brit.settings.heroku as h; "
-                    "expected = {'ssl_cert_reqs': ssl.CERT_REQUIRED}; "
+                    "expected = {'ssl_cert_reqs': ssl.CERT_NONE}; "
                     "assert h.CELERY_BROKER_USE_SSL == expected; "
                     "assert h.CELERY_REDIS_BACKEND_USE_SSL == expected"
                 ),


### PR DESCRIPTION
Fixes the production outage where file exports 500 with `SSL: CERTIFICATE_VERIFY_FAILED ... self-signed certificate in certificate chain` when Celery dispatches tasks.

`brit/settings/heroku.py` set `ssl.CERT_REQUIRED` for `CELERY_BROKER_USE_SSL` / `CELERY_REDIS_BACKEND_USE_SSL`, but Heroku Redis presents self-signed certificates, so every broker/result-backend connection failed and ended in `Retry limit exceeded while trying to reconnect to the Celery result store backend`. This reverts both to `ssl.CERT_NONE`, matching the cache connection pool kwargs, and updates the settings test accordingly.

## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Verification

- [x] Focused tests or checks were run: `brit-worktree-test` → `brit.tests` (60 tests, OK), including updated `ProductionRedisSettingsTests.test_tls_redis_accepts_self_signed_certificates` (red before fix, green after).
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed. (n/a)
- [x] No secrets, raw data, or production-only configuration are included.

Link to Devin session: https://app.devin.ai/sessions/0a80391558b9433a982b7da7c3697f54
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->