### PR TITLE
fix(waste-atlas): restore archived collections in historical maps

### DIFF
--- a/sources/waste_collection/tests/test_viewsets.py
+++ b/sources/waste_collection/tests/test_viewsets.py
@@ -4556,6 +4556,71 @@ class WasteAtlasPublicationScopingTests(APITestCase):
             publication_status="review",
         )
 
+        # Historical (2022) collections in their own catchments. Archived data
+        # was necessarily published before (``archive`` only transitions from
+        # ``published``), so it must remain visible in historical-year maps,
+        # while private/review/declined data must never leak.
+        cls.archived_catchment = CollectionCatchment.objects.create(
+            name="Archived Catchment",
+            region=cls._region_with_borders("Archived Region"),
+        )
+        cls.archived_collector = Collector.objects.create(
+            name="Archived Collector",
+            catchment=cls.archived_catchment,
+        )
+        cls.archived_collection = Collection.objects.create(
+            name="Archived Collection",
+            owner=cls.user,
+            catchment=cls.archived_catchment,
+            waste_category=cls.bio_category,
+            collection_system=cls.d2d,
+            valid_from=date(2022, 1, 1),
+            publication_status="archived",
+            collector=cls.archived_collector,
+        )
+
+        cls.historical_private_catchment = CollectionCatchment.objects.create(
+            name="Historical Private Catchment",
+            region=cls._region_with_borders("Historical Private Region"),
+        )
+        cls.historical_private_collection = Collection.objects.create(
+            name="Historical Private Collection",
+            owner=cls.user,
+            catchment=cls.historical_private_catchment,
+            waste_category=cls.bio_category,
+            collection_system=cls.d2d,
+            valid_from=date(2022, 1, 1),
+            publication_status="private",
+        )
+
+        cls.historical_review_catchment = CollectionCatchment.objects.create(
+            name="Historical Review Catchment",
+            region=cls._region_with_borders("Historical Review Region"),
+        )
+        cls.historical_review_collection = Collection.objects.create(
+            name="Historical Review Collection",
+            owner=cls.user,
+            catchment=cls.historical_review_catchment,
+            waste_category=cls.bio_category,
+            collection_system=cls.d2d,
+            valid_from=date(2022, 1, 1),
+            publication_status="review",
+        )
+
+        cls.historical_declined_catchment = CollectionCatchment.objects.create(
+            name="Historical Declined Catchment",
+            region=cls._region_with_borders("Historical Declined Region"),
+        )
+        cls.historical_declined_collection = Collection.objects.create(
+            name="Historical Declined Collection",
+            owner=cls.user,
+            catchment=cls.historical_declined_catchment,
+            waste_category=cls.bio_category,
+            collection_system=cls.d2d,
+            valid_from=date(2022, 1, 1),
+            publication_status="declined",
+        )
+
     def _get(self, endpoint_key, **extra_params):
         params = {"country": "DE", "year": 2024, **extra_params}
         return self.client.get(self.ENDPOINTS[endpoint_key], params)
@@ -4656,3 +4721,38 @@ class WasteAtlasPublicationScopingTests(APITestCase):
         self.assertIn(self.published_catchment.id, ids)
         self.assertNotIn(self.private_catchment.id, ids)
         self.assertNotIn(self.review_catchment.id, ids)
+
+    # --- Historical-year archived visibility ---
+
+    HISTORICAL_ENDPOINTS = (
+        "collection_system",
+        "catchment_geojson",
+        "collection_orga_level",
+    )
+
+    def test_archived_visible_in_historical_maps_for_anonymous(self):
+        """Previously-published (archived) collections show in historical maps."""
+        for key in self.HISTORICAL_ENDPOINTS:
+            response = self._get(key, year=2022)
+            self.assertEqual(response.status_code, status.HTTP_200_OK, key)
+            ids = self._catchment_ids(response)
+            self.assertIn(self.archived_catchment.id, ids, key)
+
+    def test_historical_maps_exclude_non_published(self):
+        """Private/review/declined data must never leak into historical maps."""
+        for key in self.HISTORICAL_ENDPOINTS:
+            response = self._get(key, year=2022)
+            self.assertEqual(response.status_code, status.HTTP_200_OK, key)
+            ids = self._catchment_ids(response)
+            self.assertNotIn(self.historical_private_catchment.id, ids, key)
+            self.assertNotIn(self.historical_review_catchment.id, ids, key)
+            self.assertNotIn(self.historical_declined_catchment.id, ids, key)
+
+    def test_staff_sees_archived_in_historical_maps(self):
+        staff = User.objects.create_user("staffhist", is_staff=True)
+        self.client.force_login(staff)
+        for key in self.HISTORICAL_ENDPOINTS:
+            response = self._get(key, year=2022)
+            self.assertEqual(response.status_code, status.HTTP_200_OK, key)
+            ids = self._catchment_ids(response)
+            self.assertIn(self.archived_catchment.id, ids, key)

--- a/sources/waste_collection/waste_atlas/viewsets.py
+++ b/sources/waste_collection/waste_atlas/viewsets.py
@@ -72,8 +72,20 @@ from .serializers import (
 )
 
 _PUBLISHED = UserCreatedObject.STATUS_PUBLISHED
+_ARCHIVED = UserCreatedObject.STATUS_ARCHIVED
+# Archived collections were necessarily published before being archived
+# (``UserCreatedObject.archive`` only transitions from ``published`` and the
+# collection version workflow archives superseded predecessors).  They are
+# therefore safe to expose in historical, year-scoped maps so that older
+# atlas years remain available after newer versions supersede them, without
+# leaking private/review/declined data.
+_PUBLIC_VISIBLE = (
+    UserCreatedObject.STATUS_PUBLISHED,
+    UserCreatedObject.STATUS_ARCHIVED,
+)
 _STAFF_VISIBLE = (
     UserCreatedObject.STATUS_PUBLISHED,
+    UserCreatedObject.STATUS_ARCHIVED,
     UserCreatedObject.STATUS_REVIEW,
     UserCreatedObject.STATUS_PRIVATE,
 )
@@ -83,15 +95,19 @@ def _is_staff(user):
     return user is not None and hasattr(user, "is_staff") and user.is_staff
 
 
+def _visible_statuses(user=None):
+    """Publication statuses visible to *user* in the year-scoped atlas maps."""
+    return _STAFF_VISIBLE if _is_staff(user) else _PUBLIC_VISIBLE
+
+
 def _collection_qs(user=None):
     """Base Collection queryset respecting publication scoping.
 
-    Staff users see published, review, and private collections so they can
-    monitor data-collection progress.  Everyone else sees only published.
+    Staff users additionally see review and private collections so they can
+    monitor data-collection progress.  Everyone sees published and archived
+    (previously published) collections so historical maps stay available.
     """
-    if _is_staff(user):
-        return Collection.objects.filter(publication_status__in=_STAFF_VISIBLE)
-    return Collection.objects.published()
+    return Collection.objects.filter(publication_status__in=_visible_statuses(user))
 
 
 def _publication_q(user=None, prefix=""):
@@ -101,9 +117,7 @@ def _publication_q(user=None, prefix=""):
     e.g. ``"collections__"`` for reverse-FK through catchments.
     """
     field = f"{prefix}publication_status"
-    if _is_staff(user):
-        return Q(**{f"{field}__in": _STAFF_VISIBLE})
-    return Q(**{field: _PUBLISHED})
+    return Q(**{f"{field}__in": _visible_statuses(user)})
 
 
 # Material IDs for food waste classification (Karte 4)


### PR DESCRIPTION
## Summary

Historical (year-scoped) Waste Atlas maps dropped catchments whose only collection had been archived when a newer version superseded it. Anonymous requests went through `Collection.objects.published()` (and `_publication_q` filtered `publication_status == "published"`), so `archived` records were excluded — e.g. catchment 1350 disappeared from the 2022 DE map because all its 2022 collections were archived.

Archiving is only reachable *from* `published` (`UserCreatedObject.archive` validates that transition, and the version workflow archives superseded predecessors), so an `archived` collection was necessarily public at some point. It is therefore safe to expose in historical maps without leaking `private`/`review`/`declined` data.

The scoping is centralized in two helpers, so the fix is a one-line semantic change routed through a new `_visible_statuses`:

```python
_PUBLIC_VISIBLE = (STATUS_PUBLISHED, STATUS_ARCHIVED)
_STAFF_VISIBLE  = (STATUS_PUBLISHED, STATUS_ARCHIVED, STATUS_REVIEW, STATUS_PRIVATE)

def _visible_statuses(user):
    return _STAFF_VISIBLE if _is_staff(user) else _PUBLIC_VISIBLE

# _collection_qs / _publication_q both now filter publication_status__in=_visible_statuses(user)
```

The year filter (`valid_from__year=year`) already scopes each map to its year, so an archived record only surfaces in the map for the year it was valid — exactly the historical-map case.

## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Verification

- [x] Focused tests or checks were run.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed. (n/a — no asset changes)
- [x] No secrets, raw data, or production-only configuration are included.

Added strict publication-scope tests to `WasteAtlasPublicationScopingTests`:
- `test_archived_visible_in_historical_maps_for_anonymous` — archived catchment appears in 2022 maps.
- `test_historical_maps_exclude_non_published` — private/review/declined stay hidden in historical maps.
- `test_staff_sees_archived_in_historical_maps` — staff sees archived too.

Tests run inside the isolated Docker worktree:
- `sources.waste_collection.tests.test_viewsets.WasteAtlasPublicationScopingTests` — 14 passed.
- `sources.waste_collection.tests.test_viewsets` — 140 passed.

Link to Devin session: https://app.devin.ai/sessions/ab228dd0095b48c58fe09b544ed03b47
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->