### PR TITLE
docs(settings): document environment configuration

### DIFF
--- a/brit/settings/.env.example
+++ b/brit/settings/.env.example
@@ -1,0 +1,61 @@
+# Copy this file to brit/settings/.env for local Docker Compose development.
+# Never commit the copied .env file or replace these placeholders with real secrets.
+
+# Required for the local PostgreSQL service and Django connection.
+POSTGRES_DB=brit
+POSTGRES_USER=brit
+POSTGRES_PASSWORD=change-me
+POSTGRES_HOST=db
+POSTGRES_PORT=5432
+
+# Required for local cache, sessions, and Celery.
+REDIS_URL=redis://redis:6379/0
+
+# Required by initial-data creation.
+ADMIN_USERNAME=admin
+
+# Recommended locally so sessions remain valid across process restarts.
+SECRET_KEY=local-development-only-change-me
+
+# Optional Docker Compose host and file-ownership overrides.
+# DB_HOST_PORT=5433
+# WEB_HOST_PORT=8000
+# UID=1000
+# GID=1000
+
+# Optional initial-data ownership and admin details.
+DEFAULT_OBJECT_OWNER_USERNAME=admin
+# ADMIN_EMAIL=admin@example.org
+# ADMIN_PASSWORD=change-me
+# ADMIN_NAME=BRIT administrator
+
+# Optional email configuration.
+# EMAIL_HOST=smtp.example.org
+# EMAIL_HOST_USER=
+# EMAIL_HOST_PASSWORD=
+# EMAIL_PORT=587
+# EMAIL_USE_SSL=false
+# DEFAULT_FROM_EMAIL=brit@example.org
+# SERVER_EMAIL=brit@example.org
+
+# Optional storage configuration.
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+# AWS_STORAGE_BUCKET_NAME=
+# AWS_DEFAULT_REGION=
+# MEDIA_ROOT=/app/media
+
+# Optional integrations and feature flags.
+# TURNSTILE_SITEKEY=
+# TURNSTILE_SECRET=
+# GOOGLE_ANALYTICS_KEY=
+# SENTRY_DSN=
+# SAMPLE_SUBSTRATE_CATEGORY_NAME=Bioresource
+# ENABLE_PDF_PARSING=false
+# AUTO_ENQUEUE_URL_CHECKS=true
+# TEST_REDIS_URL=redis://redis:6379/15
+
+# Production values belong in the deployment platform, not this local file:
+# DJANGO_SETTINGS_MODULE=brit.settings.heroku
+# ALLOWED_HOSTS=brit.example.org
+# DATABASE_URL=postgresql://user:password@host:5432/database

--- a/brit/tests/test_environment_documentation.py
+++ b/brit/tests/test_environment_documentation.py
@@ -1,0 +1,27 @@
+from django.conf import settings
+from django.test import SimpleTestCase
+
+
+class EnvironmentExampleTests(SimpleTestCase):
+    def test_local_example_contains_core_variables(self):
+        example_path = settings.BASE_DIR / "brit" / "settings" / ".env.example"
+
+        self.assertTrue(example_path.exists())
+
+        variables = {
+            line.partition("=")[0]
+            for line in example_path.read_text().splitlines()
+            if line and not line.startswith("#") and "=" in line
+        }
+        expected_variables = {
+            "ADMIN_USERNAME",
+            "POSTGRES_DB",
+            "POSTGRES_HOST",
+            "POSTGRES_PASSWORD",
+            "POSTGRES_PORT",
+            "POSTGRES_USER",
+            "REDIS_URL",
+            "SECRET_KEY",
+        }
+
+        self.assertSetEqual(expected_variables - variables, set())

--- a/docs/02_developer_guide/architecture/deployment.md
+++ b/docs/02_developer_guide/architecture/deployment.md
@@ -38,6 +38,65 @@ This page describes BRIT deployment architecture and boundaries. It is not the s
 - **Configuration**
   Secrets and environment-specific settings must come from environment variables or platform configuration, not committed files.
 
+## Environment Configuration
+
+### Local Docker Compose
+
+Copy the committed example before starting the stack:
+
+```sh
+cp brit/settings/.env.example brit/settings/.env
+```
+
+The copied file is ignored by Git. Keep real credentials only in that local file or
+an external secret manager.
+
+| Variable | Requirement | Purpose |
+|---|---|---|
+| `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` | Required | Create and authenticate the local PostgreSQL database. |
+| `POSTGRES_HOST`, `POSTGRES_PORT` | Required | Connect Django and helper containers to PostgreSQL; the example uses `db:5432`. |
+| `REDIS_URL` | Required | Back cache, sessions, and Celery; the example uses the Compose Redis service. |
+| `ADMIN_USERNAME` | Required | Create or locate the administrator during initial-data setup. |
+| `SECRET_KEY` | Recommended | Keep local sessions stable across process restarts. Use a development-only value. |
+| `DB_HOST_PORT`, `WEB_HOST_PORT`, `UID`, `GID` | Optional | Override published ports or asset-builder file ownership in Docker Compose. |
+| `TEST_REDIS_URL` | Optional | Point tests at a dedicated Redis database; test settings otherwise derive one from `REDIS_URL`. |
+| Remaining example variables | Optional | Enable email, storage, bot protection, monitoring, analytics, PDF parsing, or override defaults. |
+
+### Production
+
+The deployment platform may inject service URLs automatically, but the following
+values must exist at runtime:
+
+| Variable | Requirement | Purpose |
+|---|---|---|
+| `DJANGO_SETTINGS_MODULE` | Required | Use `brit.settings.heroku` for both web and Celery processes. |
+| `SECRET_KEY` | Required | Sign sessions and CSRF data; PR #280 adds fail-fast startup validation. |
+| `ALLOWED_HOSTS` | Required | Comma-separated public hostnames accepted by Django. |
+| `DATABASE_URL` | Required | Connect to production PostgreSQL/PostGIS. |
+| `REDIS_URL` | Required | Back cache, sessions, Celery broker, and Celery results. |
+| `ADMIN_USERNAME` | Required | Create or locate the administrator during initial-data setup. |
+| `AWS_STORAGE_BUCKET_NAME`, `AWS_DEFAULT_REGION` | Required | Configure production static and media storage. |
+| `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | Conditional | Required when the runtime does not supply an AWS role or workload identity. |
+
+Optional production configuration:
+
+| Variables | Purpose |
+|---|---|
+| `DEFAULT_OBJECT_OWNER_USERNAME` | Override the owner assigned to initial shared objects; defaults to `ADMIN_USERNAME`. |
+| `ADMIN_NAME`, `ADMIN_EMAIL`, `ADMIN_PASSWORD` | Configure error-report recipients and initial administrator details. |
+| `EMAIL_HOST`, `EMAIL_HOST_USER`, `EMAIL_HOST_PASSWORD`, `EMAIL_PORT`, `EMAIL_USE_SSL`, `DEFAULT_FROM_EMAIL`, `SERVER_EMAIL` | Enable SMTP delivery and sender identities. |
+| `TURNSTILE_SITEKEY`, `TURNSTILE_SECRET` | Enable production Cloudflare Turnstile keys for registration. |
+| `SENTRY_DSN` | Enable Django and Celery error monitoring. |
+| `GOOGLE_ANALYTICS_KEY` | Enable Google Analytics. |
+| `SAMPLE_SUBSTRATE_CATEGORY_NAME` | Override the default `Bioresource` sample category. |
+| `ENABLE_PDF_PARSING` | Enable PDF parsing when the image includes the optional dependencies. |
+| `AUTO_ENQUEUE_URL_CHECKS` | Control automatic bibliography URL checks; defaults to `true`. |
+| `WORKERS` | Override the container's default of three Gunicorn workers. |
+| `PORT`, `DJANGO_WSGI` | Override container runtime defaults; deployment platforms normally manage these. |
+
+Do not copy the example's placeholder values into production. Provision production
+secrets through the deployment platform or a dedicated secret manager.
+
 ## Release Responsibilities
 
 - **Development workflow**
@@ -60,4 +119,4 @@ This page describes BRIT deployment architecture and boundaries. It is not the s
 - **Operations runbook**
   See [../../03_operations/operations.md](../../03_operations/operations.md).
 
-_Last updated: 2026-03-06_
+_Last updated: 2026-07-11_

--- a/docs/02_developer_guide/guidelines.md
+++ b/docs/02_developer_guide/guidelines.md
@@ -29,6 +29,18 @@ This page is the canonical source for day-to-day development workflow in BRIT.
 
 ## Local Development
 
+### Configure the environment
+
+Create the ignored local environment file from the committed example:
+
+```sh
+cp brit/settings/.env.example brit/settings/.env
+```
+
+Replace the development placeholders before starting Docker Compose. The complete
+required/optional variable reference is in
+[Deployment Overview](architecture/deployment.md#environment-configuration).
+
 ### Start the stack
 
 ```sh

--- a/docs/05_roadmap/README.md
+++ b/docs/05_roadmap/README.md
@@ -232,9 +232,11 @@ Duplication is concentrated in three patterns; fix the pattern in L0 once, then 
 
 Consolidated hardening (single issue with checklist; see appendix):
 
-- Production must fail hard when `SECRET_KEY` is missing instead of inheriting the
-  development fallback.
-- Celery↔Redis certificate verification is addressed in PR #276.
+- Production fail-fast behavior for a missing `SECRET_KEY` is addressed in PR #280.
+- PR #276 required Celery↔Redis certificate verification, while PR #281 restored the
+  explicit `CERT_NONE` exception required by Heroku Redis self-signed certificates.
+  Keep this platform exception documented and revisit it if the provider trust model
+  changes.
 - Cache `IGNORE_EXCEPTIONS=True` remains for availability while PR #277 adds
   production `django_redis` error logging.
 - Typed `EMAIL_USE_SSL` parsing and valid-only `ADMINS` configuration are addressed
@@ -242,12 +244,13 @@ Consolidated hardening (single issue with checklist; see appendix):
 - PR #278 adds Django's built-in report-only CSP baseline. Enforce CSP after the
   asset pipeline emits nonces for the remaining inline scripts and styles.
 - Optional Sentry monitoring for Django and Celery is addressed in PR #279.
-- Add `.env.example`; document required vs optional variables.
+- Add `.env.example`; document required vs optional variables. **In progress in this
+  slice.**
 - `brit/urls.py` catch-all `path("<str:short_code>/", DynamicRedirectView...)`
   swallows arbitrary root paths — audit interaction with 404 handling and bots.
 
-**Status:** active; PRs #275–#279 are in review. The next slice makes production
-fail fast when `SECRET_KEY` is missing.
+**Status:** active; PRs #275–#279 are merged and PR #280 is in review. Environment
+examples/documentation are the current slice; the root-path catch-all audit follows.
 
 ### WS8 — Inventories/scenario subsystem: decide, then act
 
@@ -305,8 +308,8 @@ consolidation that pays compounding dividends.
 **Phase 0 — Safety (immediately, days)**
 1. Waste Atlas publication scoping fix + regression test (WS3.1) — completed in PR #260
 2. CI workflow running the full suite + ruff (WS6.1) — completed in commit `f9b34b09`
-3. Settings hardening checklist (WS7) — active; PRs #275–#279 are in review and
-   production `SECRET_KEY` validation is the next slice (#166)
+3. Settings hardening checklist (WS7) — active; PRs #275–#279 are merged, PR #280 is
+   in review, and environment documentation is the current slice (#166)
 4. Atomic review-state transitions (WS2.1) — completed in PR #273
 
 **Phase 1 — Foundation inversion (next, ~1 month)**


### PR DESCRIPTION
## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Summary

- Add a copy-safe `brit/settings/.env.example` for local Compose with only development placeholders enabled and optional integrations commented out.
- Classify local, production, container-runtime, and test environment variables by requirement and purpose.
- Add a focused regression test ensuring the core local example remains complete.
- Advance WS7 status through merged PRs #275–#279, open PR #280, and the Heroku Redis compatibility exception from PR #281.

## Verification

- [x] Focused tests or checks were run.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed. (Not applicable.)
- [x] No secrets, raw data, or production-only configuration are included.

Commands run:

- `brit-worktree-test ... -- brit.tests.test_environment_documentation`
- `ruff check .`
- `ruff format --check .`
- `python manage.py check --settings=brit.settings.testrunner`
- `python manage.py makemigrations --check --dry-run`
- `uv lock --check`
- `mkdocs build`

`mkdocs build --strict` remains blocked by the repository's existing 19 warnings for missing operations/design-decision pages; the new environment-documentation link resolves successfully.

Link to Devin session: https://app.devin.ai/sessions/6aa9cba393f44e288f5bf307fac2d262
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->