### PR TITLE
fix(urls): preserve root 404 handling

### DIFF
--- a/brit/settings/settings.py
+++ b/brit/settings/settings.py
@@ -71,6 +71,7 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
+    "utils.middleware.DynamicRedirectFallbackMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "ambient_toolbox.middleware.current_user.CurrentUserMiddleware",

--- a/brit/settings/testrunner.py
+++ b/brit/settings/testrunner.py
@@ -101,6 +101,7 @@ COOKIE_CONSENT_ENABLED = False
 
 MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "utils.middleware.DynamicRedirectFallbackMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "maps.middleware.CacheMonitoringMiddleware",

--- a/brit/tests/test_urls.py
+++ b/brit/tests/test_urls.py
@@ -1,5 +1,7 @@
-from django.test import SimpleTestCase
-from django.urls import reverse
+from django.test import SimpleTestCase, TestCase
+from django.urls import Resolver404, resolve, reverse
+
+from utils.models import Redirect
 
 
 class SessionUrlRoutingTests(SimpleTestCase):
@@ -10,3 +12,31 @@ class SessionUrlRoutingTests(SimpleTestCase):
     def test_get_session_url_resolves(self):
         url = reverse("get_session")
         self.assertEqual(url, "/get_session/")
+
+
+class DynamicRedirectRoutingTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        Redirect.objects.create(short_code="docs", full_path="/learning/")
+
+    def test_short_code_redirects_with_or_without_trailing_slash(self):
+        for path in ("/docs", "/docs/"):
+            with self.subTest(path=path):
+                response = self.client.get(path)
+
+                self.assertEqual(response.status_code, 302)
+                self.assertEqual(response.url, "http://testserver/learning/")
+
+    def test_unknown_root_path_without_trailing_slash_returns_404(self):
+        response = self.client.get("/not-a-short-code")
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_unknown_root_path_is_not_resolved_as_a_redirect(self):
+        with self.assertRaises(Resolver404):
+            resolve("/not-a-short-code/")
+
+    def test_unknown_root_post_returns_404(self):
+        response = self.client.post("/not-a-short-code/")
+
+        self.assertEqual(response.status_code, 404)

--- a/brit/urls.py
+++ b/brit/urls.py
@@ -10,7 +10,6 @@ from sources.registry import (
     get_source_domain_legacy_redirects,
     get_source_domain_public_mounts,
 )
-from utils.views import DynamicRedirectView
 
 from .sitemaps import DynamicViewSitemap, HomepageSitemap
 from .views import (
@@ -74,7 +73,6 @@ urlpatterns = [
     path("cache-test/", CacheTestView.as_view(), name="cache_test"),
     path("set_session/", set_session, name="set_session"),
     path("get_session/", get_session, name="get_session"),
-    path("<str:short_code>/", DynamicRedirectView.as_view(), name="redirect"),
 ]
 
 if settings.DEBUG:

--- a/docs/05_roadmap/README.md
+++ b/docs/05_roadmap/README.md
@@ -244,13 +244,14 @@ Consolidated hardening (single issue with checklist; see appendix):
 - PR #278 adds Django's built-in report-only CSP baseline. Enforce CSP after the
   asset pipeline emits nonces for the remaining inline scripts and styles.
 - Optional Sentry monitoring for Django and Celery is addressed in PR #279.
-- Add `.env.example`; document required vs optional variables. **In progress in this
+- Safe `.env.example` and required/optional variable documentation are addressed in
+  PR #283.
+- Replace the root short-code catch-all with a 404 fallback so arbitrary bot paths
+  remain unresolved and unsupported methods return 404. **In progress in this
   slice.**
-- `brit/urls.py` catch-all `path("<str:short_code>/", DynamicRedirectView...)`
-  swallows arbitrary root paths — audit interaction with 404 handling and bots.
 
-**Status:** active; PRs #275–#279 are merged and PR #280 is in review. Environment
-examples/documentation are the current slice; the root-path catch-all audit follows.
+**Status:** active; PRs #275–#280 and #283 are merged. Root short-code routing is the
+current slice.
 
 ### WS8 — Inventories/scenario subsystem: decide, then act
 
@@ -308,8 +309,8 @@ consolidation that pays compounding dividends.
 **Phase 0 — Safety (immediately, days)**
 1. Waste Atlas publication scoping fix + regression test (WS3.1) — completed in PR #260
 2. CI workflow running the full suite + ruff (WS6.1) — completed in commit `f9b34b09`
-3. Settings hardening checklist (WS7) — active; PRs #275–#279 are merged, PR #280 is
-   in review, and environment documentation is the current slice (#166)
+3. Settings hardening checklist (WS7) — active; PRs #275–#280 and #283 are merged,
+   and root short-code routing is the current slice (#166)
 4. Atomic review-state transitions (WS2.1) — completed in PR #273
 
 **Phase 1 — Foundation inversion (next, ~1 month)**

--- a/utils/middleware.py
+++ b/utils/middleware.py
@@ -1,0 +1,37 @@
+import re
+
+from django.http import HttpResponseRedirect
+
+from .models import Redirect
+
+SHORT_CODE_PATH = re.compile(r"/(?P<short_code>[^/]{1,50})/?\Z")
+
+
+class DynamicRedirectFallbackMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        if (
+            response.status_code != 404
+            or request.method not in {"GET", "HEAD"}
+            or request.resolver_match is not None
+        ):
+            return response
+
+        match = SHORT_CODE_PATH.fullmatch(request.path_info)
+        if match is None:
+            return response
+
+        full_path = (
+            Redirect.objects.filter(short_code=match["short_code"])
+            .values_list("full_path", flat=True)
+            .first()
+        )
+        if full_path is None:
+            return response
+
+        return HttpResponseRedirect(
+            f"{request.scheme}://{request.get_host()}{full_path}"
+        )

--- a/utils/views.py
+++ b/utils/views.py
@@ -2,12 +2,8 @@ from urllib.parse import urlencode
 
 from crispy_forms.helper import FormHelper
 from django.http import HttpResponseRedirect, JsonResponse
-from django.shortcuts import render
 from django.template.loader import render_to_string
-from django.views import View
 from django.views.generic import ListView, TemplateView
-
-from .models import Redirect
 
 
 def build_breadcrumb_context(
@@ -251,19 +247,3 @@ class UtilsDashboardView(BreadcrumbContextMixin, TemplateView):
     template_name = "utils_dashboard.html"
     breadcrumb_module_label = "Utilities"
     breadcrumb_page_title = "Utilities"
-
-
-class DynamicRedirectView(View):
-    """
-    A view that handles dynamic redirection based on a short code.
-    If no such object exists, it returns a proper 404 response without logging an error.
-    """
-
-    def get(self, request, short_code):
-        try:
-            redirect_obj = Redirect.objects.get(short_code=short_code)
-            return HttpResponseRedirect(
-                f"{request.scheme}://{request.get_host()}{redirect_obj.full_path}"
-            )
-        except Redirect.DoesNotExist:
-            return render(request, "404.html", status=404)


### PR DESCRIPTION
## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Summary

Replace the final root `<str:short_code>` URL pattern with a response fallback that runs only after normal URL resolution returns 404. Existing short codes redirect with or without a trailing slash, while arbitrary root paths remain unresolved and unsupported bot methods return 404 instead of being claimed by `DynamicRedirectView`.

Advance WS7 after merged PRs #280 and #283 and mark root short-code routing as the current safety slice.

Refs #166

## Verification

- [x] Focused tests or checks were run.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed. Not applicable; no assets changed.
- [x] No secrets, raw data, or production-only configuration are included.

Commands run:

- `brit-worktree-test ... -- brit.tests.test_urls` (6 passed)
- `brit-worktree-test ... -- brit.tests utils.tests` (139 passed)
- `ruff check .`
- `ruff format --check .`
- `python manage.py check --settings=brit.settings.testrunner`
- `python manage.py makemigrations --check --dry-run --settings=brit.settings.testrunner`
- `uv lock --check`
- `mkdocs build` (passes with the repository's existing missing-page warnings)

Link to Devin session: https://app.devin.ai/sessions/6aa9cba393f44e288f5bf307fac2d262
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->