### PR TITLE
feat(object-management): expose manage-access modal in the UI

### DIFF
--- a/brit/templates/detail_with_options.html
+++ b/brit/templates/detail_with_options.html
@@ -174,6 +174,9 @@
                     {% endif %}
                   {% endif %}
                 {% endblock options_primary_actions %}
+                {% block options_access_actions %}
+                  {% include "object_management/manage_access_button.html" with object=object policy=policy %}
+                {% endblock options_access_actions %}
                 {% block options_secondary_actions %}
                 {% endblock options_secondary_actions %}
                 {% block options_review_actions %}

--- a/sources/waste_collection/templates/waste_collection/collection_detail.html
+++ b/sources/waste_collection/templates/waste_collection/collection_detail.html
@@ -557,6 +557,7 @@
       <i class="fas fa-archive"></i> Archive
     </a>
   {% endif %}
+  {% include "object_management/manage_access_button.html" with object=object policy=policy %}
   {# Delete #}
   {% if policy.can_delete %}
     <a class="btn btn-outline-danger modal-link w-100 mb-2"

--- a/utils/object_management/templates/object_management/manage_access_button.html
+++ b/utils/object_management/templates/object_management/manage_access_button.html
@@ -1,0 +1,7 @@
+{% load moderation_tags %}
+{% if policy.can_manage_editors %}
+  <a class="btn btn-outline-secondary w-100 mb-2 modal-link"
+     href="{% url 'object_management:manage_access_modal' content_type_id=object|get_content_type_id object_id=object.id %}?next={{ request.get_full_path|urlencode }}">
+    <i class="fas fa-user-group"></i> Manage access
+  </a>
+{% endif %}

--- a/utils/object_management/templates/object_management/status_actions_cell.html
+++ b/utils/object_management/templates/object_management/status_actions_cell.html
@@ -55,6 +55,14 @@
         </a>
       {% endif %}
 
+      {# Manage access: transfer ownership and shared edit access (owner or staff) #}
+      {% if policy.can_manage_editors %}
+        <a class="dropdown-item modal-link"
+           href="{% url 'object_management:manage_access_modal' content_type_id=object|get_content_type_id object_id=object.id %}?next={{ request.get_full_path|urlencode }}">
+          <i class="fas fa-user-group"></i> Manage access
+        </a>
+      {% endif %}
+
       {# Delete via policy (supports modal_delete_url or delete_url) #}
       {% if policy.can_delete %}
         {% if object.modal_delete_url %}

--- a/utils/object_management/templatetags/moderation_tags.py
+++ b/utils/object_management/templatetags/moderation_tags.py
@@ -183,6 +183,9 @@ def _safe_policy_fallback(user, obj, review_mode=False):
         "can_withdraw_review": False,
         "can_approve": False,
         "can_reject": False,
+        "can_transfer_ownership": False,
+        "can_manage_editors": False,
+        "is_editor": False,
         "can_export": (is_published or is_archived)
         or (is_authenticated and (is_owner or is_staff)),
         "export_list_type": export_list_type,

--- a/utils/object_management/tests/test_ownership_sharing.py
+++ b/utils/object_management/tests/test_ownership_sharing.py
@@ -328,6 +328,22 @@ class OwnershipSharingViewTests(TestCase):
             },
         )
 
+    def test_detail_page_shows_manage_access_button_for_owner(self):
+        self.client.force_login(self.owner)
+        response = self.client.get(self.collection.get_absolute_url())
+        self.assertContains(response, self._url("manage_access_modal"))
+
+    def test_detail_page_shows_manage_access_button_for_staff(self):
+        self.client.force_login(self.staff)
+        response = self.client.get(self.collection.get_absolute_url())
+        self.assertContains(response, self._url("manage_access_modal"))
+
+    def test_detail_page_hides_manage_access_button_for_editor(self):
+        self.collection.add_editor(self.editor)
+        self.client.force_login(self.editor)
+        response = self.client.get(self.collection.get_absolute_url())
+        self.assertNotContains(response, self._url("manage_access_modal"))
+
     def test_owner_can_transfer_ownership(self):
         self.client.force_login(self.owner)
         response = self.client.post(

--- a/utils/object_management/tests/test_ownership_sharing.py
+++ b/utils/object_management/tests/test_ownership_sharing.py
@@ -363,6 +363,18 @@ class OwnershipSharingViewTests(TestCase):
         )
         self.assertEqual(response.status_code, 403)
 
+    def test_manage_access_modal_dispatches_transfer_post(self):
+        # django-bootstrap-modal-forms rewrites the form action to the modal
+        # URL, so the modal view must dispatch the transfer POST itself.
+        self.client.force_login(self.owner)
+        response = self.client.post(
+            self._url("manage_access_modal"),
+            {"new_owner": self.new_owner.username},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.collection.refresh_from_db()
+        self.assertEqual(self.collection.owner, self.new_owner)
+
     def test_owner_can_transfer_ownership(self):
         self.client.force_login(self.owner)
         response = self.client.post(

--- a/utils/object_management/tests/test_ownership_sharing.py
+++ b/utils/object_management/tests/test_ownership_sharing.py
@@ -342,6 +342,8 @@ class OwnershipSharingViewTests(TestCase):
         self.collection.add_editor(self.editor)
         self.client.force_login(self.editor)
         response = self.client.get(self.collection.get_absolute_url())
+        # Editors can read the page but must not see the manage-access button.
+        self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, self._url("manage_access_modal"))
 
     def test_manage_access_modal_ajax_preflight_returns_204_for_owner(self):
@@ -362,6 +364,16 @@ class OwnershipSharingViewTests(TestCase):
             HTTP_X_REQUESTED_WITH="XMLHttpRequest",
         )
         self.assertEqual(response.status_code, 403)
+
+    def test_transfer_with_querystring_next_falls_back_when_unreadable(self):
+        self.client.force_login(self.owner)
+        detail_url = self.collection.get_absolute_url()
+        response = self.client.post(
+            self._url("transfer_ownership"),
+            {"new_owner": self.new_owner.username, "next": f"{detail_url}?tab=info"},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "/")
 
     def test_manage_access_modal_dispatches_transfer_post(self):
         # django-bootstrap-modal-forms rewrites the form action to the modal

--- a/utils/object_management/tests/test_ownership_sharing.py
+++ b/utils/object_management/tests/test_ownership_sharing.py
@@ -344,6 +344,25 @@ class OwnershipSharingViewTests(TestCase):
         response = self.client.get(self.collection.get_absolute_url())
         self.assertNotContains(response, self._url("manage_access_modal"))
 
+    def test_manage_access_modal_ajax_preflight_returns_204_for_owner(self):
+        self.client.force_login(self.owner)
+        response = self.client.post(
+            self._url("manage_access_modal"),
+            {"new_owner": self.new_owner.username},
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(response.status_code, 204)
+        self.collection.refresh_from_db()
+        self.assertEqual(self.collection.owner, self.owner)
+
+    def test_manage_access_modal_ajax_preflight_denied_for_non_owner(self):
+        self.client.force_login(self.other)
+        response = self.client.post(
+            self._url("manage_access_modal"),
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+        self.assertEqual(response.status_code, 403)
+
     def test_owner_can_transfer_ownership(self):
         self.client.force_login(self.owner)
         response = self.client.post(

--- a/utils/object_management/views.py
+++ b/utils/object_management/views.py
@@ -19,7 +19,12 @@ from django.core.exceptions import (
     ValidationError,
 )
 from django.db.models import Q
-from django.http import Http404, HttpResponse, HttpResponseRedirect
+from django.http import (
+    Http404,
+    HttpResponse,
+    HttpResponseNotAllowed,
+    HttpResponseRedirect,
+)
 from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string, select_template
 from django.urls import NoReverseMatch, reverse
@@ -1444,6 +1449,17 @@ class ManageAccessModalView(BaseObjectAccessActionView):
             "object_id": self.kwargs.get("object_id"),
         }
         return HttpResponse(render_to_string(self.template_name, context, request))
+
+    def post(self, request, *args, **kwargs):
+        """Preflight handling for django-bootstrap-modal-forms.
+
+        The plugin sends an AJAX POST to the modal URL before submitting the
+        form natively to its action. Respond with 204 so the real submit
+        proceeds; the actual work happens in the action views.
+        """
+        if request.headers.get("x-requested-with") == "XMLHttpRequest":
+            return HttpResponse(status=204)
+        return HttpResponseNotAllowed(["GET"])
 
 
 class UserOwnsObjectMixin(UserPassesTestMixin):

--- a/utils/object_management/views.py
+++ b/utils/object_management/views.py
@@ -1453,12 +1453,15 @@ class ManageAccessModalView(BaseObjectAccessActionView):
     def post(self, request, *args, **kwargs):
         """Preflight handling for django-bootstrap-modal-forms.
 
-        The plugin sends an AJAX POST to the modal URL before submitting the
-        form natively to its action. Respond with 204 so the real submit
-        proceeds; the actual work happens in the action views.
+        The plugin sends an AJAX POST to the modal URL first; respond with 204
+        so it proceeds with the real submit. Because it rewrites the form's
+        action to the modal URL before submitting, the real transfer POST also
+        arrives here and is dispatched to ``TransferOwnershipView``.
         """
         if request.headers.get("x-requested-with") == "XMLHttpRequest":
             return HttpResponse(status=204)
+        if "new_owner" in request.POST:
+            return TransferOwnershipView.as_view()(request, *args, **kwargs)
         return HttpResponseNotAllowed(["GET"])
 
 

--- a/utils/object_management/views.py
+++ b/utils/object_management/views.py
@@ -1374,7 +1374,7 @@ class TransferOwnershipView(BaseObjectAccessActionView):
         ):
             # The former owner may no longer read the object; avoid a 403.
             try:
-                if success_url == obj.get_absolute_url():
+                if urlparse(success_url).path == urlparse(obj.get_absolute_url()).path:
                     success_url = "/"
             except Exception:
                 success_url = "/"
@@ -1462,7 +1462,7 @@ class ManageAccessModalView(BaseObjectAccessActionView):
             return HttpResponse(status=204)
         if "new_owner" in request.POST:
             return TransferOwnershipView.as_view()(request, *args, **kwargs)
-        return HttpResponseNotAllowed(["GET"])
+        return HttpResponseNotAllowed(["GET", "POST"])
 
 
 class UserOwnsObjectMixin(UserPassesTestMixin):


### PR DESCRIPTION
Follow-up to #286: wires the ownership-transfer / shared-edit-access modal into the UI.

- New reusable include `object_management/manage_access_button.html`: a "Manage access" `modal-link` button shown when `policy.can_manage_editors` (owner or staff), linking to `object_management:manage_access_modal` with `?next=`.
- Rendered in three places:
  - `detail_with_options.html` options pane (new `options_access_actions` block) — inherited by all standard detail pages.
  - `collection_detail.html` custom options pane (which overrides `options_pane` entirely).
  - `status_actions_cell.html` row-actions dropdown for list views.
- `ManageAccessModalView.post`: django-bootstrap-modal-forms rewrites the first form's action to the modal URL before submitting, so the view answers the AJAX preflight with 204 and dispatches the real transfer POST (payload containing `new_owner`) server-side to `TransferOwnershipView`; other non-AJAX POSTs → 405.
- Tests: detail page shows the button for owner and staff, hides it for editors/others; modal preflight 204/403; transfer dispatch through the modal URL.

Browser-verified end-to-end (see PR comment with recording evidence): open modal from detail page and list dropdown, add/remove editor, transfer ownership, former owner loses access, new owner gains full control.

## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Verification

- [x] Focused tests or checks were run: `utils.object_management.tests.test_ownership_sharing` plus nearby `utils.object_management`, `utils.tests`, `sources.waste_collection.tests.test_views/test_viewsets`, `materials.tests.test_views` — all OK; ruff clean; CI green; 3 rounds of live browser testing.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed (templates only, no JS/CSS changes).
- [x] No secrets, raw data, or production-only configuration are included.

Link to Devin session: https://app.devin.ai/sessions/0e0cbf0bacd049a3b8c1587d55082146
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->