### PR TITLE
fix(settings): allow intentional CDN assets in report-only CSP

### DIFF
--- a/brit/settings/heroku.py
+++ b/brit/settings/heroku.py
@@ -47,9 +47,31 @@ MIDDLEWARE.insert(1, "django.middleware.csp.ContentSecurityPolicyMiddleware")
 # This middleware is added only in production because it triggers too many logging events during testing in development.
 MIDDLEWARE.append("brit.middleware.ExceptionLoggingMiddleware")
 
+AWS_S3_ORIGIN = f"https://{AWS_S3_CUSTOM_DOMAIN}"
+
 SECURE_CSP_REPORT_ONLY = {
     "default-src": [CSP.SELF],
-    "style-src": [CSP.SELF],
+    "style-src": [
+        CSP.SELF,
+        AWS_S3_ORIGIN,
+        "https://cdn.jsdelivr.net",
+        "https://cdnjs.cloudflare.com",
+        "https://fonts.googleapis.com",
+    ],
+    "script-src": [
+        CSP.SELF,
+        AWS_S3_ORIGIN,
+        "https://cdn.jsdelivr.net",
+        "https://cdnjs.cloudflare.com",
+        "https://www.googletagmanager.com",
+    ],
+    "font-src": [
+        CSP.SELF,
+        AWS_S3_ORIGIN,
+        "https://cdnjs.cloudflare.com",
+        "https://fonts.gstatic.com",
+    ],
+    "img-src": [CSP.SELF, AWS_S3_ORIGIN, "data:"],
     "base-uri": [CSP.SELF],
     "frame-ancestors": [CSP.SELF],
     "object-src": [CSP.NONE],

--- a/brit/tests/test_security_settings.py
+++ b/brit/tests/test_security_settings.py
@@ -10,6 +10,7 @@ class ProductionContentSecurityPolicyTests(SimpleTestCase):
         environment = os.environ.copy()
         environment["DJANGO_SETTINGS_MODULE"] = "brit.settings.heroku"
         environment["SECRET_KEY"] = "test-secret-key"
+        environment["AWS_STORAGE_BUCKET_NAME"] = "brit-test-assets"
         completed = subprocess.run(
             [
                 sys.executable,
@@ -28,7 +29,15 @@ middleware = ContentSecurityPolicyMiddleware(lambda request: HttpResponse("ok"))
 response = middleware(RequestFactory().get("/"))
 expected = (
     "default-src 'self'; "
-    "style-src 'self'; "
+    "style-src 'self' https://brit-test-assets.s3.amazonaws.com "
+    "https://cdn.jsdelivr.net https://cdnjs.cloudflare.com "
+    "https://fonts.googleapis.com; "
+    "script-src 'self' https://brit-test-assets.s3.amazonaws.com "
+    "https://cdn.jsdelivr.net https://cdnjs.cloudflare.com "
+    "https://www.googletagmanager.com; "
+    "font-src 'self' https://brit-test-assets.s3.amazonaws.com "
+    "https://cdnjs.cloudflare.com https://fonts.gstatic.com; "
+    "img-src 'self' https://brit-test-assets.s3.amazonaws.com data:; "
     "base-uri 'self'; "
     "frame-ancestors 'self'; "
     "object-src 'none'"


### PR DESCRIPTION
## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md` (not applicable; no helper infrastructure added).

## Summary

- Expand only resource-specific report-only CSP directives for the intentional Bootstrap, D3, Mermaid, Font Awesome, Chart.js, Google Fonts, and consent-gated Google Analytics script hosts.
- Derive the production S3 origin from `AWS_S3_CUSTOM_DOMAIN` and allow it for static styles/scripts/fonts plus media images; allow `data:` only for images embedded by the approved Bootstrap stylesheet.
- Keep `default-src`, `base-uri`, `frame-ancestors`, and `object-src` unchanged, and do not add `unsafe-inline`, nonces, hashes, wildcards, or enforcing CSP.
- Update the fresh-process middleware assertion to verify the exact report-only header with a deterministic S3 host.

Existing inline scripts remain report-only violations by design and need a separate nonce/hash/extraction decision before enforcement.

## Verification

- [x] Focused tests or checks were run.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed (not applicable; no asset sources changed).
- [x] No secrets, raw data, or production-only configuration are included.

Commands:

```text
$HOME/BRIT-ops/scripts/brit-worktree-test "$PWD" --print-targets
$HOME/BRIT-ops/scripts/brit-worktree-test "$PWD"
$HOME/BRIT-ops/scripts/brit-worktree-test "$PWD" -- brit.tests.test_security_settings brit.tests.test_settings
uv run ruff check brit/settings/heroku.py brit/tests/test_security_settings.py
uv run ruff format --check brit/settings/heroku.py brit/tests/test_security_settings.py
```

The TDD red run failed on the expanded exact header as expected. The green inferred run passed 67 tests, and the explicit nearby run passed 8 tests.

Link to Devin session: https://app.devin.ai/sessions/4f56709ffb0a4af8a7c5b34eb7fca854
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->