### PR TITLE
feat(object-management): bulk access management for selected and all owned objects

### DIFF
--- a/brit/templates/filtered_list.html
+++ b/brit/templates/filtered_list.html
@@ -81,12 +81,16 @@
                 </p>
               {% endif %}
             {% endblock list_result_count %}
+            {% if list_type == 'private' and object_list.model|is_user_created and user.is_authenticated %}
+              {% include "object_management/bulk_access_toolbar.html" %}
+            {% endif %}
             {% block list_table %}
               <div class="table-responsive">
                 <table class="table modern-table">
                   {% block list_table_head %}
                     <thead>
                       <tr>
+                        {% include "object_management/bulk_select_th.html" %}
                         <th>Name</th>
                         {% if object_list.model|is_user_created %}<th class="actions-column">Status/Actions</th>{% endif %}
                       </tr>
@@ -99,6 +103,7 @@
                             role="link"
                             onclick="window.location='{% detail_or_review_url object use_back=True %}'"
                             onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();window.location='{% detail_or_review_url object use_back=True %}'}">
+                          {% include "object_management/bulk_select_td.html" %}
                           <td data-label="Name" class="ps-3">
                             <a href="{% detail_or_review_url object use_back=True %}"
                                class="text-decoration-none">

--- a/brit/templates/filtered_list.html
+++ b/brit/templates/filtered_list.html
@@ -81,10 +81,10 @@
                 </p>
               {% endif %}
             {% endblock list_result_count %}
-            {% if list_type == 'private' and object_list.model|is_user_created and user.is_authenticated %}
-              {% include "object_management/bulk_access_toolbar.html" %}
-            {% endif %}
             {% block list_table %}
+              {% if list_type == 'private' and object_list.model|is_user_created and user.is_authenticated %}
+                {% include "object_management/bulk_access_toolbar.html" %}
+              {% endif %}
               <div class="table-responsive">
                 <table class="table modern-table">
                   {% block list_table_head %}
@@ -117,7 +117,11 @@
                         </tr>
                       {% endblock list_table_row %}
                     {% empty %}
-                      {% include "includes/list_empty_state.html" %}
+                      {% if list_type == 'private' and object_list.model|is_user_created %}
+                        {% include "includes/list_empty_state.html" with colspan=3 %}
+                      {% else %}
+                        {% include "includes/list_empty_state.html" %}
+                      {% endif %}
                     {% endfor %}
                   </tbody>
                   {% block list_table_footer %}

--- a/sources/waste_collection/templates/waste_collection/collection_filter.html
+++ b/sources/waste_collection/templates/waste_collection/collection_filter.html
@@ -25,6 +25,9 @@
 {% endblock title %}
 {% block list_table %}
     {% load custom_tags %}
+    {% if list_type == 'private' and user.is_authenticated %}
+        {% include "object_management/bulk_access_toolbar.html" %}
+    {% endif %}
     {% if chips %}
         <div class="mb-2 d-flex flex-wrap gap-2">
             {% for chip in chips %}
@@ -68,7 +71,11 @@
                             <td class="actions-column mobile-no-label">{% include "object_management/status_actions_cell.html" %}</td>
                         </tr>
                     {% empty %}
-                        {% include "includes/list_empty_state.html" %}
+                        {% if list_type == 'private' %}
+                            {% include "includes/list_empty_state.html" with colspan=3 %}
+                        {% else %}
+                            {% include "includes/list_empty_state.html" %}
+                        {% endif %}
                     {% endfor %}
                 </tbody>
             </table>

--- a/sources/waste_collection/templates/waste_collection/collection_filter.html
+++ b/sources/waste_collection/templates/waste_collection/collection_filter.html
@@ -47,6 +47,7 @@
             <table class="table modern-table">
                 <thead>
                     <tr>
+                        {% include "object_management/bulk_select_th.html" %}
                         <th>Collection</th>
                         <th class="actions-column">Status/Actions</th>
                     </tr>
@@ -54,6 +55,7 @@
                 <tbody>
                     {% for object in object_list %}
                         <tr>
+                            {% include "object_management/bulk_select_td.html" %}
                             <td data-label="Collection" class="ps-3">
                                 <a href="{% detail_or_review_url object use_back=True %}"
                                    class="collection-link">

--- a/users/templates/user_profile.html
+++ b/users/templates/user_profile.html
@@ -19,6 +19,11 @@
     </div>
 
     <div class="pt-3">
+        <p><b>Access to all my objects:</b></p>
+        {% include "object_management/bulk_access_toolbar.html" with all_owned=True %}
+    </div>
+
+    <div class="pt-3">
         <a href="{% url 'auth_password_change' %}" class="btn btn-primary w-100">
             Change password
         </a>

--- a/utils/object_management/templates/object_management/bulk_access_toolbar.html
+++ b/utils/object_management/templates/object_management/bulk_access_toolbar.html
@@ -1,0 +1,31 @@
+{# Bulk access management form.
+   Context:
+   - all_owned: if truthy, applies to every object owned by the user
+     (no item checkboxes required); otherwise checkboxes elsewhere in the
+     page reference this form via form="bulk-access-form". #}
+<form id="bulk-access-form"
+      method="post"
+      action="{% url 'object_management:bulk_manage_access' %}"
+      class="d-flex flex-wrap align-items-center gap-2 {% if not all_owned %}mb-3{% endif %}"
+      onsubmit="return this.bulk_action.value !== 'transfer_ownership' || confirm('Transfer ownership of the affected items? This cannot be undone from your side.')">
+  {% csrf_token %}
+  <input type="hidden" name="next" value="{{ request.get_full_path }}">
+  {% if all_owned %}<input type="hidden" name="all_owned" value="1">{% endif %}
+  <select name="bulk_action"
+          class="form-select form-select-sm w-auto"
+          aria-label="Bulk access action">
+    <option value="add_editor">Grant edit access</option>
+    <option value="remove_editor">Revoke edit access</option>
+    <option value="transfer_ownership">Transfer ownership</option>
+  </select>
+  <input type="text"
+         name="username"
+         class="form-control form-control-sm w-auto"
+         placeholder="Username"
+         required
+         aria-label="Username">
+  <button type="submit" class="btn btn-sm btn-outline-primary">
+    <i class="fas fa-user-group"></i>
+    {% if all_owned %}Apply to all my items{% else %}Apply to selected{% endif %}
+  </button>
+</form>

--- a/utils/object_management/templates/object_management/bulk_access_toolbar.html
+++ b/utils/object_management/templates/object_management/bulk_access_toolbar.html
@@ -1,8 +1,9 @@
-{# Bulk access management form.
-   Context:
-   - all_owned: if truthy, applies to every object owned by the user
-     (no item checkboxes required); otherwise checkboxes elsewhere in the
-     page reference this form via form="bulk-access-form". #}
+{% comment %}
+Bulk access management form. Context:
+- all_owned: if truthy, applies to every object owned by the user (no item
+  checkboxes required); otherwise checkboxes elsewhere in the page reference
+  this form via form="bulk-access-form".
+{% endcomment %}
 <form id="bulk-access-form"
       method="post"
       action="{% url 'object_management:bulk_manage_access' %}"

--- a/utils/object_management/templates/object_management/bulk_access_toolbar.html
+++ b/utils/object_management/templates/object_management/bulk_access_toolbar.html
@@ -28,4 +28,15 @@
     <i class="fas fa-user-group"></i>
     {% if all_owned %}Apply to all my items{% else %}Apply to selected{% endif %}
   </button>
+  {% if not all_owned %}
+    <script>
+      // Templates with custom tables may not render selection checkboxes;
+      // hide the toolbar there instead of offering a dead control.
+      document.addEventListener('DOMContentLoaded', function () {
+        if (!document.querySelector('input[name=items]')) {
+          document.getElementById('bulk-access-form').classList.add('d-none');
+        }
+      });
+    </script>
+  {% endif %}
 </form>

--- a/utils/object_management/templates/object_management/bulk_select_td.html
+++ b/utils/object_management/templates/object_management/bulk_select_td.html
@@ -1,0 +1,10 @@
+{% load moderation_tags user_created_object_tags %}
+{% if list_type == 'private' and object_list.model|is_user_created %}
+  <td class="bulk-select-column mobile-no-label" onclick="event.stopPropagation()">
+    <input type="checkbox"
+           form="bulk-access-form"
+           name="items"
+           value="{{ object|get_content_type_id }}:{{ object.id }}"
+           aria-label="Select {{ object.name }}">
+  </td>
+{% endif %}

--- a/utils/object_management/templates/object_management/bulk_select_td.html
+++ b/utils/object_management/templates/object_management/bulk_select_td.html
@@ -1,6 +1,7 @@
 {% load moderation_tags user_created_object_tags %}
 {% if list_type == 'private' and object_list.model|is_user_created %}
-  <td class="bulk-select-column mobile-no-label" onclick="event.stopPropagation()">
+  <td class="bulk-select-column mobile-no-label" onclick="event.stopPropagation()"
+      onkeydown="event.stopPropagation()">
     <input type="checkbox"
            form="bulk-access-form"
            name="items"

--- a/utils/object_management/templates/object_management/bulk_select_th.html
+++ b/utils/object_management/templates/object_management/bulk_select_th.html
@@ -1,0 +1,8 @@
+{% load user_created_object_tags %}
+{% if list_type == 'private' and object_list.model|is_user_created %}
+  <th class="bulk-select-column">
+    <input type="checkbox"
+           aria-label="Select all items"
+           onclick="document.querySelectorAll('input[name=items]').forEach(cb => cb.checked = this.checked)">
+  </th>
+{% endif %}

--- a/utils/object_management/tests/test_bulk_manage_access.py
+++ b/utils/object_management/tests/test_bulk_manage_access.py
@@ -225,6 +225,19 @@ class BulkManageAccessViewTests(TestCase):
         self.assertContains(response, reverse("object_management:bulk_manage_access"))
         self.assertContains(response, 'name="all_owned"')
 
+    def test_no_next_falls_back_to_private_list_of_model(self):
+        self.client.force_login(self.owner)
+        response = self.client.post(
+            self.url,
+            {
+                "bulk_action": "add_editor",
+                "username": self.editor.username,
+                "items": [self._item(self.collection_a)],
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, f"{Collection.private_list_url()}?scope=private")
+
     def test_external_next_is_ignored(self):
         self.client.force_login(self.owner)
         response = self.client.post(

--- a/utils/object_management/tests/test_bulk_manage_access.py
+++ b/utils/object_management/tests/test_bulk_manage_access.py
@@ -1,0 +1,240 @@
+from django.contrib.auth.models import User
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+from django.urls import reverse
+
+from sources.waste_collection.models import Collection
+
+from ..models import UserCreatedObject
+
+
+class BulkManageAccessViewTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.owner = User.objects.create_user(username="owner", password="pw")
+        cls.editor = User.objects.create_user(username="editor", password="pw")
+        cls.new_owner = User.objects.create_user(username="new_owner", password="pw")
+        cls.other = User.objects.create_user(username="other", password="pw")
+        cls.staff = User.objects.create_user(
+            username="staff", password="pw", is_staff=True
+        )
+        cls.collection_a = Collection.objects.create(
+            name="Collection A",
+            owner=cls.owner,
+            publication_status=UserCreatedObject.STATUS_PRIVATE,
+        )
+        cls.collection_b = Collection.objects.create(
+            name="Collection B",
+            owner=cls.owner,
+            publication_status=UserCreatedObject.STATUS_PRIVATE,
+        )
+        cls.foreign_collection = Collection.objects.create(
+            name="Foreign Collection",
+            owner=cls.other,
+            publication_status=UserCreatedObject.STATUS_PRIVATE,
+        )
+        cls.content_type = ContentType.objects.get_for_model(Collection)
+        cls.url = reverse("object_management:bulk_manage_access")
+
+    def _item(self, obj):
+        return f"{self.content_type.pk}:{obj.pk}"
+
+    def test_bulk_add_editor_to_selected_objects(self):
+        self.client.force_login(self.owner)
+        response = self.client.post(
+            self.url,
+            {
+                "bulk_action": "add_editor",
+                "username": self.editor.username,
+                "items": [self._item(self.collection_a), self._item(self.collection_b)],
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(self.collection_a.editors.filter(pk=self.editor.pk).exists())
+        self.assertTrue(self.collection_b.editors.filter(pk=self.editor.pk).exists())
+
+    def test_bulk_remove_editor_from_selected_objects(self):
+        self.collection_a.add_editor(self.editor)
+        self.collection_b.add_editor(self.editor)
+        self.client.force_login(self.owner)
+        response = self.client.post(
+            self.url,
+            {
+                "bulk_action": "remove_editor",
+                "username": self.editor.username,
+                "items": [self._item(self.collection_a), self._item(self.collection_b)],
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(self.collection_a.editors.filter(pk=self.editor.pk).exists())
+        self.assertFalse(self.collection_b.editors.filter(pk=self.editor.pk).exists())
+
+    def test_bulk_transfer_ownership_of_selected_objects(self):
+        self.client.force_login(self.owner)
+        response = self.client.post(
+            self.url,
+            {
+                "bulk_action": "transfer_ownership",
+                "username": self.new_owner.username,
+                "items": [self._item(self.collection_a), self._item(self.collection_b)],
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.collection_a.refresh_from_db()
+        self.collection_b.refresh_from_db()
+        self.assertEqual(self.collection_a.owner, self.new_owner)
+        self.assertEqual(self.collection_b.owner, self.new_owner)
+
+    def test_bulk_skips_objects_without_permission(self):
+        self.client.force_login(self.owner)
+        response = self.client.post(
+            self.url,
+            {
+                "bulk_action": "add_editor",
+                "username": self.editor.username,
+                "items": [
+                    self._item(self.collection_a),
+                    self._item(self.foreign_collection),
+                ],
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(self.collection_a.editors.filter(pk=self.editor.pk).exists())
+        self.assertFalse(
+            self.foreign_collection.editors.filter(pk=self.editor.pk).exists()
+        )
+
+    def test_staff_can_bulk_manage_foreign_objects(self):
+        self.client.force_login(self.staff)
+        response = self.client.post(
+            self.url,
+            {
+                "bulk_action": "add_editor",
+                "username": self.editor.username,
+                "items": [self._item(self.foreign_collection)],
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(
+            self.foreign_collection.editors.filter(pk=self.editor.pk).exists()
+        )
+
+    def test_all_owned_add_editor(self):
+        self.client.force_login(self.owner)
+        response = self.client.post(
+            self.url,
+            {
+                "bulk_action": "add_editor",
+                "username": self.editor.username,
+                "all_owned": "1",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(self.collection_a.editors.filter(pk=self.editor.pk).exists())
+        self.assertTrue(self.collection_b.editors.filter(pk=self.editor.pk).exists())
+        self.assertFalse(
+            self.foreign_collection.editors.filter(pk=self.editor.pk).exists()
+        )
+
+    def test_all_owned_transfer_ownership(self):
+        self.client.force_login(self.owner)
+        response = self.client.post(
+            self.url,
+            {
+                "bulk_action": "transfer_ownership",
+                "username": self.new_owner.username,
+                "all_owned": "1",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.collection_a.refresh_from_db()
+        self.collection_b.refresh_from_db()
+        self.foreign_collection.refresh_from_db()
+        self.assertEqual(self.collection_a.owner, self.new_owner)
+        self.assertEqual(self.collection_b.owner, self.new_owner)
+        self.assertEqual(self.foreign_collection.owner, self.other)
+
+    def test_unknown_username_fails_gracefully(self):
+        self.client.force_login(self.owner)
+        response = self.client.post(
+            self.url,
+            {
+                "bulk_action": "add_editor",
+                "username": "does-not-exist",
+                "items": [self._item(self.collection_a)],
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(self.collection_a.editors.exists())
+
+    def test_invalid_action_rejected(self):
+        self.client.force_login(self.owner)
+        response = self.client.post(
+            self.url,
+            {
+                "bulk_action": "delete_everything",
+                "username": self.editor.username,
+                "items": [self._item(self.collection_a)],
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_malformed_items_are_ignored(self):
+        self.client.force_login(self.owner)
+        response = self.client.post(
+            self.url,
+            {
+                "bulk_action": "add_editor",
+                "username": self.editor.username,
+                "items": ["not-an-item", "999999:1", self._item(self.collection_a)],
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(self.collection_a.editors.filter(pk=self.editor.pk).exists())
+
+    def test_anonymous_redirected_to_login(self):
+        response = self.client.post(
+            self.url,
+            {
+                "bulk_action": "add_editor",
+                "username": self.editor.username,
+                "items": [self._item(self.collection_a)],
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("login", response.url)
+
+    def test_private_list_shows_bulk_access_controls(self):
+        self.client.force_login(self.owner)
+        response = self.client.get(reverse("collection-list-owned"), follow=True)
+        self.assertContains(response, reverse("object_management:bulk_manage_access"))
+        self.assertContains(
+            response, f'value="{self.content_type.pk}:{self.collection_a.pk}"'
+        )
+
+    def test_published_list_hides_bulk_access_controls(self):
+        self.client.force_login(self.owner)
+        response = self.client.get(reverse("collection-list"), follow=True)
+        self.assertNotContains(
+            response, reverse("object_management:bulk_manage_access")
+        )
+
+    def test_profile_page_shows_all_owned_access_form(self):
+        self.client.force_login(self.owner)
+        response = self.client.get(reverse("user_profile"))
+        self.assertContains(response, reverse("object_management:bulk_manage_access"))
+        self.assertContains(response, 'name="all_owned"')
+
+    def test_external_next_is_ignored(self):
+        self.client.force_login(self.owner)
+        response = self.client.post(
+            self.url,
+            {
+                "bulk_action": "add_editor",
+                "username": self.editor.username,
+                "items": [self._item(self.collection_a)],
+                "next": "https://evil.example/",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertNotIn("evil.example", response.url)

--- a/utils/object_management/tests/test_ownership_sharing.py
+++ b/utils/object_management/tests/test_ownership_sharing.py
@@ -373,7 +373,7 @@ class OwnershipSharingViewTests(TestCase):
             {"new_owner": self.new_owner.username, "next": f"{detail_url}?tab=info"},
         )
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, "/")
+        self.assertEqual(response.url, f"{Collection.private_list_url()}?scope=private")
 
     def test_manage_access_modal_dispatches_transfer_post(self):
         # django-bootstrap-modal-forms rewrites the form action to the modal
@@ -520,7 +520,19 @@ class OwnershipSharingViewTests(TestCase):
             {"new_owner": self.other.username},
         )
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, "/")
+        self.assertEqual(response.url, f"{Collection.private_list_url()}?scope=private")
+
+    def test_transfer_of_published_object_stays_on_detail(self):
+        self.collection.publication_status = UserCreatedObject.STATUS_PUBLISHED
+        self.collection.save()
+        self.client.force_login(self.staff)
+        detail_url = self.collection.get_absolute_url()
+        response = self.client.post(
+            self._url("transfer_ownership"),
+            {"new_owner": self.other.username, "next": detail_url},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, detail_url)
 
     def test_external_next_url_is_ignored(self):
         self.client.force_login(self.owner)

--- a/utils/object_management/urls.py
+++ b/utils/object_management/urls.py
@@ -88,6 +88,11 @@ urlpatterns = [
         name="remove_editor",
     ),
     path(
+        "bulk-manage-access/",
+        views.BulkManageAccessView.as_view(),
+        name="bulk_manage_access",
+    ),
+    path(
         "modal/manage-access/<int:content_type_id>/<int:object_id>/",
         views.ManageAccessModalView.as_view(),
         name="manage_access_modal",

--- a/utils/object_management/views.py
+++ b/utils/object_management/views.py
@@ -22,6 +22,7 @@ from django.db.models import Q
 from django.http import (
     Http404,
     HttpResponse,
+    HttpResponseBadRequest,
     HttpResponseNotAllowed,
     HttpResponseRedirect,
 )
@@ -1463,6 +1464,117 @@ class ManageAccessModalView(BaseObjectAccessActionView):
         if "new_owner" in request.POST:
             return TransferOwnershipView.as_view()(request, *args, **kwargs)
         return HttpResponseNotAllowed(["GET", "POST"])
+
+
+class BulkManageAccessView(LoginRequiredMixin, View):
+    """Apply an access-management action to multiple UserCreatedObjects.
+
+    Accepts POST data:
+    - ``bulk_action``: ``add_editor`` | ``remove_editor`` | ``transfer_ownership``
+    - ``username``: the target user
+    - ``items``: repeated ``<content_type_id>:<object_id>`` values, or
+    - ``all_owned``: apply to every object owned by the requesting user
+    - ``next``: optional safe redirect target
+
+    Objects the requesting user may not manage are skipped; a summary
+    message reports applied and skipped counts.
+    """
+
+    actions = {
+        "add_editor": "has_manage_editors_permission",
+        "remove_editor": "has_manage_editors_permission",
+        "transfer_ownership": "has_transfer_ownership_permission",
+    }
+
+    def post(self, request, *args, **kwargs):
+        action = request.POST.get("bulk_action")
+        permission_method = self.actions.get(action)
+        if permission_method is None:
+            return HttpResponseBadRequest("Unknown bulk action.")
+
+        from django.contrib.auth.models import User
+
+        username = (request.POST.get("username") or "").strip()
+        try:
+            target_user = User.objects.get(username=username)
+        except User.DoesNotExist:
+            messages.error(request, "The specified user does not exist.")
+            return HttpResponseRedirect(self._success_url(request))
+
+        objects = self._resolve_objects(request)
+        perm = UserCreatedObjectPermission()
+        checker = getattr(perm, permission_method)
+        applied = skipped = 0
+        for obj in objects:
+            try:
+                if not checker(request, obj):
+                    skipped += 1
+                    continue
+                if action == "add_editor":
+                    obj.add_editor(target_user, granted_by=request.user)
+                elif action == "remove_editor":
+                    obj.remove_editor(target_user)
+                else:
+                    obj.transfer_ownership(target_user, initiator=request.user)
+                applied += 1
+            except (ValidationError, PermissionDenied):
+                skipped += 1
+
+        label = {
+            "add_editor": f"Granted edit access to {target_user.username}",
+            "remove_editor": f"Revoked edit access from {target_user.username}",
+            "transfer_ownership": f"Transferred ownership to {target_user.username}",
+        }[action]
+        if applied:
+            messages.success(request, f"{label} for {applied} item(s).")
+        if skipped:
+            messages.warning(request, f"Skipped {skipped} item(s).")
+        if not applied and not skipped:
+            messages.info(request, "No items selected.")
+        return HttpResponseRedirect(self._success_url(request))
+
+    def _resolve_objects(self, request):
+        if request.POST.get("all_owned"):
+            from django.apps import apps
+
+            objects = []
+            for model in apps.get_models():
+                if (
+                    issubclass(model, UserCreatedObject)
+                    and not model._meta.abstract
+                    and not model._meta.proxy
+                ):
+                    objects.extend(model.objects.filter(owner=request.user))
+            return objects
+
+        objects = []
+        for item in request.POST.getlist("items"):
+            try:
+                content_type_id, object_id = item.split(":", 1)
+                content_type = ContentType.objects.get(pk=int(content_type_id))
+                model_class = content_type.model_class()
+                if model_class is None or not issubclass(
+                    model_class, UserCreatedObject
+                ):
+                    continue
+                objects.append(model_class.objects.get(pk=int(object_id)))
+            except (
+                ValueError,
+                ContentType.DoesNotExist,
+                ObjectDoesNotExist,
+            ):
+                continue
+        return objects
+
+    def _success_url(self, request):
+        next_url = request.POST.get("next") or request.GET.get("next")
+        if next_url and url_has_allowed_host_and_scheme(
+            next_url,
+            allowed_hosts={request.get_host()},
+            require_https=request.is_secure(),
+        ):
+            return next_url
+        return "/"
 
 
 class UserOwnsObjectMixin(UserPassesTestMixin):

--- a/utils/object_management/views.py
+++ b/utils/object_management/views.py
@@ -1373,13 +1373,25 @@ class TransferOwnershipView(BaseObjectAccessActionView):
             or policy["is_staff"]
             or policy["is_moderator"]
         ):
-            # The former owner may no longer read the object; avoid a 403.
+            # The former owner may no longer read the object; avoid a 403 by
+            # falling back to the model's private list, or the start page as
+            # a last resort.
             try:
                 if urlparse(success_url).path == urlparse(obj.get_absolute_url()).path:
-                    success_url = "/"
+                    success_url = self._unreadable_fallback_url(obj)
             except Exception:
-                success_url = "/"
+                success_url = self._unreadable_fallback_url(obj)
         return HttpResponseRedirect(success_url)
+
+    @staticmethod
+    def _unreadable_fallback_url(obj):
+        try:
+            list_url = type(obj).private_list_url()
+            if list_url:
+                return f"{list_url}?scope=private"
+        except Exception:
+            pass
+        return "/"
 
 
 class AddEditorView(BaseObjectAccessActionView):
@@ -1502,6 +1514,7 @@ class BulkManageAccessView(LoginRequiredMixin, View):
             return HttpResponseRedirect(self._success_url(request))
 
         objects = self._resolve_objects(request)
+        self._objects = objects
         perm = UserCreatedObjectPermission()
         checker = getattr(perm, permission_method)
         applied = skipped = 0
@@ -1574,6 +1587,13 @@ class BulkManageAccessView(LoginRequiredMixin, View):
             require_https=request.is_secure(),
         ):
             return next_url
+        for obj in getattr(self, "_objects", []):
+            try:
+                list_url = type(obj).private_list_url()
+                if list_url:
+                    return f"{list_url}?scope=private"
+            except Exception:
+                continue
         return "/"
 
 


### PR DESCRIPTION
Follow-up to #287 (stacked on that branch): bulk access management + smarter post-transfer redirects.

- New `BulkManageAccessView` at `object_management:bulk_manage_access` (POST only, login required): `bulk_action` ∈ {`add_editor`, `remove_editor`, `transfer_ownership`}, `username`, and either repeated `items` values (`<content_type_id>:<object_id>`) or `all_owned=1` (every `UserCreatedObject` owned by the requester across all models). Per-object permission checks via `UserCreatedObjectPermission`; unauthorized or invalid objects are skipped and reported in a summary message. Safe `next` redirect only.
- UI A — private list views: reusable `bulk_select_th.html`/`bulk_select_td.html` includes add a checkbox column (with select-all) shown only for `list_type == 'private'`; checkboxes attach to the `bulk_access_toolbar.html` form via the HTML `form` attribute. Wired into `filtered_list.html` (inside the default `list_table` block) and the Collection list's custom `list_table` block; a JS guard hides the toolbar on templates without selection checkboxes. Transfer asks for confirm(). Checkbox cells stop click and keydown propagation so row navigation isn't triggered.
- UI B — user profile: same toolbar with `all_owned=1` to apply an action to every object the user owns.
- Redirect priority (single and bulk transfer): stay on `next` if the object is still readable (e.g. published, or staff/moderator/editor initiator) → otherwise the model's private list (`private_list_url()?scope=private`) → start page only as last resort.

Tests: `test_bulk_manage_access` (16) + updated `test_ownership_sharing` (52) cover bulk add/remove/transfer via items and all_owned, permission skipping, staff override, unknown user, invalid action → 400, malformed items ignored, anonymous → login redirect, external `next` ignored, UI rendering, and the redirect fallback chain.

Browser-verified end-to-end (see PR comment with recording evidence): bulk grant/revoke/transfer with DB-verified changes, select-all, profile apply-to-all, published lists untouched, toolbar hidden on lists without checkboxes.

## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Verification

- [x] Focused tests or checks were run: `utils.object_management` + `utils.tests` (348 tests OK) plus earlier nearby runs (`users`, `sources.waste_collection.tests.test_views`, `materials.tests.test_views` — 2924 tests OK); ruff format + check clean; live browser testing.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed (templates only).
- [x] No secrets, raw data, or production-only configuration are included.

Link to Devin session: https://app.devin.ai/sessions/0e0cbf0bacd049a3b8c1587d55082146
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->