### PR TITLE
test(file_export): silence expected export-task error logs in CI

### DIFF
--- a/utils/file_export/tests/test_export_registry.py
+++ b/utils/file_export/tests/test_export_registry.py
@@ -1,4 +1,6 @@
+import logging
 from collections import OrderedDict, namedtuple
+from contextlib import contextmanager
 from io import BytesIO
 from unittest.mock import MagicMock, patch
 
@@ -217,6 +219,30 @@ TaskExportSpec = namedtuple(
 )
 
 
+@contextmanager
+def silence_export_task_logging():
+    """Silence expected export-task error logs.
+
+    These unit tests mock ``write_file_for_download``, so the export file is
+    never written and the task's file-size lookup raises an expected error.
+    That error is handled gracefully; suppressing it keeps the test output
+    clean without hiding genuine failures (assertions still catch those).
+    """
+    logger = logging.getLogger("utils.file_export.generic_tasks")
+    handler = logging.NullHandler()
+    original_level = logger.level
+    original_propagate = logger.propagate
+    logger.addHandler(handler)
+    logger.propagate = False
+    logger.setLevel(logging.CRITICAL)
+    try:
+        yield
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(original_level)
+        logger.propagate = original_propagate
+
+
 class ExportTaskTestCase(TestCase):
     """Tests for export_user_created_object_to_file."""
 
@@ -230,7 +256,8 @@ class ExportTaskTestCase(TestCase):
         mock_self = MagicMock()
         mock_self.request.id = "fake-request-id"
         run_fn = export_user_created_object_to_file.run.__func__
-        result = run_fn(mock_self, model_label, file_format, query_params, context)
+        with silence_export_task_logging():
+            result = run_fn(mock_self, model_label, file_format, query_params, context)
         return result, mock_self
 
     def _make_spec(self, model=User):

--- a/utils/file_export/tests/test_user_exports.py
+++ b/utils/file_export/tests/test_user_exports.py
@@ -165,13 +165,16 @@ class ExportTaskRecordTests(TestCase):
                     "create",
                     side_effect=RuntimeError("db down"),
                 ):
-                    with self.assertRaises(RuntimeError):
-                        self._run_task(
-                            "auth.User",
-                            "csv",
-                            {},
-                            {"user_id": self.owner.pk, "list_type": "public"},
-                        )
+                    with self.assertLogs(
+                        "utils.file_export.generic_tasks", level="ERROR"
+                    ):
+                        with self.assertRaises(RuntimeError):
+                            self._run_task(
+                                "auth.User",
+                                "csv",
+                                {},
+                                {"user_id": self.owner.pk, "list_type": "public"},
+                            )
                 storage = get_file_export_storage()
                 self.assertFalse(storage.exists("user_fake-request-id.csv"))
 


### PR DESCRIPTION
## Summary

The `export_user_created_object_to_file` task tests emitted ERROR tracebacks into CI logs even though every test passed, because they exercise handled failure paths:

- Tests in `ExportTaskTestCase` (`test_export_registry.py`) mock `write_file_for_download`, so no file is written and the task's `storage.size(...)` lookup raises `FileNotFoundError` → logged via `logger.exception("Could not determine export file size ...")`, then swallowed (`file_size = None`).
- `test_task_deletes_file_when_record_creation_fails` (`test_user_exports.py`) makes `UserExport.objects.create` raise `RuntimeError("db down")` on purpose → logged via `logger.exception("Could not record export ...")`, file deleted, error re-raised.

These are expected, handled errors, but the tracebacks polluted CI output and confused debugging agents about which failure was real. Production logging is unchanged.

Changes (tests only):
- Added a `silence_export_task_logging()` context manager in `test_export_registry.py` and wrapped `_run_task` with it, so the incidental file-size errors don't propagate to the console.
- Wrapped the db-down path in `test_user_exports.py` with `self.assertLogs(...)`, which both asserts the error is logged and captures it instead of printing.

## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Verification

- [x] Focused tests or checks were run: `utils.file_export.tests.test_export_registry` and `utils.file_export.tests.test_user_exports` (55 tests, all pass, no ERROR tracebacks in output).
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed. (n/a)
- [x] No secrets, raw data, or production-only configuration are included.


Link to Devin session: https://app.devin.ai/sessions/554aebb0ae24454888ddbfa561f1d208
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/297" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->