### PR TITLE
feat(maps): scope user-facing NUTS queries to a single vintage

### DIFF
--- a/maps/filters.py
+++ b/maps/filters.py
@@ -57,9 +57,22 @@ class RegionFilterSet(UserCreatedObjectScopedFilterSet):
         )
 
 
+def _nuts_level_queryset(level):
+    """Current-vintage regions of one level, resolved per request.
+
+    A callable keeps the vintage lookup out of import time and picks up a
+    change of current vintage without a restart.
+    """
+
+    def queryset(request):
+        return NutsRegion.objects.in_vintage().filter(levl_code=level)
+
+    return queryset
+
+
 class NutsRegionFilterSet(BaseCrispyFilterSet):
     level_0 = ModelChoiceFilter(
-        queryset=NutsRegion.objects.filter(levl_code=0),
+        queryset=_nuts_level_queryset(0),
         field_name="region_ptr",
         widget=TomSelectModelWidget(
             config=TomSelectConfig(
@@ -73,7 +86,7 @@ class NutsRegionFilterSet(BaseCrispyFilterSet):
     )
 
     level_1 = ModelChoiceFilter(
-        queryset=NutsRegion.objects.filter(levl_code=1),
+        queryset=_nuts_level_queryset(1),
         field_name="region_ptr",
         widget=TomSelectModelWidget(
             config=TomSelectConfig(
@@ -88,7 +101,7 @@ class NutsRegionFilterSet(BaseCrispyFilterSet):
     )
 
     level_2 = ModelChoiceFilter(
-        queryset=NutsRegion.objects.filter(levl_code=2),
+        queryset=_nuts_level_queryset(2),
         field_name="levl_code",
         widget=TomSelectModelWidget(
             config=TomSelectConfig(
@@ -103,7 +116,7 @@ class NutsRegionFilterSet(BaseCrispyFilterSet):
     )
 
     level_3 = ModelChoiceFilter(
-        queryset=NutsRegion.objects.filter(levl_code=3),
+        queryset=_nuts_level_queryset(3),
         field_name="levl_code",
         widget=TomSelectModelWidget(
             config=TomSelectConfig(

--- a/maps/models.py
+++ b/maps/models.py
@@ -398,9 +398,11 @@ def set_country(sender, instance, created, **kwargs):
         # Buffer the region’s geometry by the tolerance.
         buffered_geom = instance.borders.geom.buffer(-settings.GEO_BORDER_TOLERANCE)
         # Look for a candidate country (NutsRegion with levl_code=0) whose borders contain the buffered geometry.
-        candidate = NutsRegion.objects.filter(
-            levl_code=0, borders__geom__contains=buffered_geom
-        ).first()
+        candidate = (
+            NutsRegion.objects.in_vintage()
+            .filter(levl_code=0, borders__geom__contains=buffered_geom)
+            .first()
+        )
         if candidate and candidate.cntr_code:
             instance.country = candidate.cntr_code
             instance.save(update_fields=["country"])
@@ -447,6 +449,21 @@ class NutsVintage(models.Model):
         return cls.objects.filter(year=int(match.group(1))).first()
 
 
+class NutsRegionQuerySet(UserCreatedObjectQuerySet):
+    def in_vintage(self, vintage=None):
+        """Scope to a single vintage, the current one unless given.
+
+        Codes repeat across vintages, so any user-facing query must pick one:
+        otherwise pickers list a territory once per vintage and map layers draw
+        duplicate overlapping features.
+        """
+        return self.filter(version=vintage or NutsVintage.current())
+
+
+class NutsRegionManager(models.Manager.from_queryset(NutsRegionQuerySet)):
+    pass
+
+
 class NutsRegion(Region):
     nuts_id = models.CharField(max_length=5, blank=True, null=True)
     version = models.ForeignKey(
@@ -466,6 +483,8 @@ class NutsRegion(Region):
         "self", related_name="children", on_delete=models.PROTECT, null=True
     )
 
+    objects = NutsRegionManager()
+
     @property
     def pedigree(self):
         pedigree = {}
@@ -479,7 +498,7 @@ class NutsRegion(Region):
         # add children
         for lvl in range(self.levl_code + 1, 4):
             pedigree[f"qs_{lvl}"] = NutsRegion.objects.filter(
-                levl_code=lvl, nuts_id__startswith=self.nuts_id
+                levl_code=lvl, nuts_id__startswith=self.nuts_id, version=self.version_id
             )
         if self.levl_code == 3:
             pedigree["qs_4"] = self.lau_children.all()

--- a/maps/tests/test_vintage_scoping.py
+++ b/maps/tests/test_vintage_scoping.py
@@ -103,6 +103,26 @@ class NutsRegionGeoJSONVintageScopeTestCase(TwoVintageTestCase):
         results = payload["results"] if isinstance(payload, dict) else payload
         self.assertEqual([entry["id"] for entry in results], [self.region_2021.pk])
 
+    def test_geojson_by_id_is_not_served_from_another_requests_cache(self):
+        first = self.client.get(self.url, {"id": self.region_2021.pk})
+        second = self.client.get(
+            self.url, {"id": self.region_2024.pk, "version": "2024"}
+        )
+        self.assertEqual(_x_origin(first.json()["features"][0]), 0.0)
+        self.assertEqual(_x_origin(second.json()["features"][0]), 10.0)
+
+    def test_cache_keys_for_one_region_still_differ_per_vintage(self):
+        self.assertNotEqual(
+            get_nuts_region_cache_key(nuts_id=4, version=2021),
+            get_nuts_region_cache_key(nuts_id=4, version=2024),
+        )
+
+    def test_cache_keys_differ_per_region(self):
+        self.assertNotEqual(
+            get_nuts_region_cache_key(nuts_id=4, version=2021),
+            get_nuts_region_cache_key(nuts_id=5, version=2021),
+        )
+
     def test_cache_keys_differ_per_vintage(self):
         self.assertNotEqual(
             get_nuts_region_cache_key(

--- a/maps/tests/test_vintage_scoping.py
+++ b/maps/tests/test_vintage_scoping.py
@@ -1,0 +1,158 @@
+"""User-facing NUTS queries must show one vintage, not every vintage at once."""
+
+from django.contrib.gis.geos import MultiPolygon, Polygon
+from django.test import TestCase
+from django.urls import reverse
+
+from ..models import GeoPolygon, NutsRegion, NutsVintage, Region
+from ..utils import get_nuts_region_cache_key
+
+
+def _x_origin(feature):
+    """First x coordinate of a feature, identifying which vintage it came from."""
+    return feature["geometry"]["coordinates"][0][0][0][0]
+
+
+def _borders(offset=0.0):
+    return GeoPolygon.objects.create(
+        geom=MultiPolygon(
+            Polygon(
+                (
+                    (offset, offset),
+                    (offset, offset + 1),
+                    (offset + 1, offset + 1),
+                    (offset + 1, offset),
+                    (offset, offset),
+                )
+            )
+        )
+    )
+
+
+class TwoVintageTestCase(TestCase):
+    """DE111 exists in both NUTS 2021 (current) and NUTS 2024."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.v2021 = NutsVintage.objects.get(year=2021)
+        cls.v2024 = NutsVintage.objects.create(year=2024)
+        cls.country_2021 = NutsRegion.objects.create(
+            name="Deutschland",
+            nuts_id="DE",
+            levl_code=0,
+            cntr_code="DE",
+            version=cls.v2021,
+        )
+        cls.country_2024 = NutsRegion.objects.create(
+            name="Deutschland",
+            nuts_id="DE",
+            levl_code=0,
+            cntr_code="DE",
+            version=cls.v2024,
+        )
+        cls.region_2021 = NutsRegion.objects.create(
+            name="Flensburg",
+            nuts_id="DE111",
+            levl_code=3,
+            cntr_code="DE",
+            parent=cls.country_2021,
+            version=cls.v2021,
+            borders=_borders(),
+        )
+        cls.region_2024 = NutsRegion.objects.create(
+            name="Flensburg",
+            nuts_id="DE111",
+            levl_code=3,
+            cntr_code="DE",
+            parent=cls.country_2024,
+            version=cls.v2024,
+            borders=_borders(10.0),
+        )
+
+
+class NutsRegionGeoJSONVintageScopeTestCase(TwoVintageTestCase):
+    def setUp(self):
+        self.url = reverse("api-nuts-region-geojson")
+
+    def test_geojson_returns_only_the_current_vintage(self):
+        response = self.client.get(self.url, {"levl_code": 3, "cntr_code": "DE"})
+        self.assertEqual(response.status_code, 200)
+        features = response.json()["features"]
+        self.assertEqual(len(features), 1)
+        self.assertEqual(_x_origin(features[0]), 0.0)
+
+    def test_geojson_accepts_an_explicit_vintage(self):
+        response = self.client.get(
+            self.url, {"levl_code": 3, "cntr_code": "DE", "version": "2024"}
+        )
+        self.assertEqual(response.status_code, 200)
+        features = response.json()["features"]
+        self.assertEqual(len(features), 1)
+        self.assertEqual(_x_origin(features[0]), 10.0)
+
+    def test_geojson_rejects_a_vintage_that_is_not_held(self):
+        response = self.client.get(
+            self.url, {"levl_code": 3, "cntr_code": "DE", "version": "2016"}
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_list_endpoint_is_scoped_as_well(self):
+        response = self.client.get(reverse("api-nuts-region-list"), {"levl_code": 3})
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        results = payload["results"] if isinstance(payload, dict) else payload
+        self.assertEqual([entry["id"] for entry in results], [self.region_2021.pk])
+
+    def test_cache_keys_differ_per_vintage(self):
+        self.assertNotEqual(
+            get_nuts_region_cache_key(
+                level=3, filters={"cntr_code": "DE"}, version=2021
+            ),
+            get_nuts_region_cache_key(
+                level=3, filters={"cntr_code": "DE"}, version=2024
+            ),
+        )
+
+
+class NutsRegionHierarchyVintageScopeTestCase(TwoVintageTestCase):
+    def test_pedigree_children_stay_within_the_regions_vintage(self):
+        children = self.country_2024.pedigree["qs_3"]
+        self.assertEqual(list(children), [self.region_2024])
+
+    def test_pedigree_api_children_stay_within_the_regions_vintage(self):
+        response = self.client.get(
+            reverse("data.nuts_region_options"),
+            {"id": self.country_2024.pk, "direction": "children"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [option["id"] for option in response.json()["id_level_3"]],
+            [self.region_2024.pk],
+        )
+
+
+class NutsRegionAutocompleteVintageScopeTestCase(TwoVintageTestCase):
+    def test_autocomplete_offers_each_territory_once(self):
+        response = self.client.get(reverse("nutsregion-autocomplete-level3"))
+        self.assertEqual(response.status_code, 200)
+        ids = [result["id"] for result in response.json()["results"]]
+        self.assertEqual(ids, [self.region_2021.pk])
+
+
+class SetCountryVintageScopeTestCase(TwoVintageTestCase):
+    def test_country_is_derived_from_the_current_vintage_only(self):
+        """A level-0 region of a non-current vintage must not claim the territory."""
+        for country in (self.country_2021, self.country_2024):
+            country.borders = GeoPolygon.objects.create(
+                geom=MultiPolygon(
+                    Polygon(((-5, -5), (-5, 5), (5, 5), (5, -5), (-5, -5)))
+                )
+            )
+            country.save()
+        # Sorts first, so an unscoped lookup would pick the 2024 row.
+        self.country_2024.name = "A Deutschland"
+        self.country_2024.cntr_code = "XX"
+        self.country_2024.save()
+
+        region = Region.objects.create(name="Child", borders=_borders())
+        self.assertEqual(region.country, "DE")

--- a/maps/utils.py
+++ b/maps/utils.py
@@ -193,13 +193,21 @@ def get_catchment_cache_key(catchment_id=None, filters=None):
     return key
 
 
-def get_nuts_region_cache_key(level=None, parent_id=None, nuts_id=None, filters=None):
-    """Generate a cache key for NUTS region GeoJSON data."""
+def get_nuts_region_cache_key(
+    level=None, parent_id=None, nuts_id=None, filters=None, version=None
+):
+    """Generate a cache key for NUTS region GeoJSON data.
+
+    ``version`` is the vintage year the response was scoped to; the same
+    code and level yield different geometries per vintage.
+    """
     # Prioritize specific NUTS ID if provided
     if nuts_id:
         return f"nuts_geojson:id:{nuts_id}"
 
     parts = ["nuts_geojson"]
+    if version is not None:
+        parts.append(f"vintage:{version}")
     if level is not None:
         parts.append(f"level:{level}")
     if parent_id is not None:
@@ -210,6 +218,7 @@ def get_nuts_region_cache_key(level=None, parent_id=None, nuts_id=None, filters=
     filters_copy.pop("levl_code", None)  # Already handled by 'level' parameter
     filters_copy.pop("parent_id", None)  # Already handled by 'parent_id' parameter
     filters_copy.pop("id", None)  # Already handled by 'nuts_id' parameter
+    filters_copy.pop("version", None)  # Already handled by 'version' parameter
 
     if filters_copy:
         filter_part = _generate_filter_key_part(filters_copy)

--- a/maps/utils.py
+++ b/maps/utils.py
@@ -199,15 +199,14 @@ def get_nuts_region_cache_key(
     """Generate a cache key for NUTS region GeoJSON data.
 
     ``version`` is the vintage year the response was scoped to; the same
-    code and level yield different geometries per vintage.
+    code and level yield different geometries per vintage, so every key
+    — including one naming a single region — carries it.
     """
-    # Prioritize specific NUTS ID if provided
-    if nuts_id:
-        return f"nuts_geojson:id:{nuts_id}"
-
     parts = ["nuts_geojson"]
     if version is not None:
         parts.append(f"vintage:{version}")
+    if nuts_id:
+        parts.append(f"id:{nuts_id}")
     if level is not None:
         parts.append(f"level:{level}")
     if parent_id is not None:
@@ -223,7 +222,7 @@ def get_nuts_region_cache_key(
     if filters_copy:
         filter_part = _generate_filter_key_part(filters_copy)
         parts.append(f"filter:{filter_part}")
-    elif len(parts) == 1:  # Only "nuts_geojson"
+    elif len(parts) == 1:  # Only "nuts_geojson", no vintage/level/parent/id
         parts.append(
             "all"
         )  # Indicate fetching all NUTS regions if no level/parent/filter

--- a/maps/views.py
+++ b/maps/views.py
@@ -1335,6 +1335,10 @@ class NutsRegionAutocompleteView(UserCreatedObjectAutocompleteView):
     search_lookups = ["region_ptr", "name_latn__icontains", "levl_code__icontains"]
     value_fields = ["id", "name_latn", "levl_code", "parent_id", "nuts_id"]
 
+    def hook_queryset(self, queryset):
+        """Offer each territory once, from the current vintage only."""
+        return queryset.in_vintage()
+
     def apply_filters(self, queryset):
         # Check for ancestor filtering (nuts_id prefix matching)
         # When ancestor is provided, skip the standard filter_by (parent_id) logic
@@ -1364,22 +1368,22 @@ class NutsRegionAutocompleteView(UserCreatedObjectAutocompleteView):
 
 class NutsRegionLevel0AutocompleteView(NutsRegionAutocompleteView):
     def hook_queryset(self, queryset):
-        return queryset.filter(levl_code=0)
+        return super().hook_queryset(queryset).filter(levl_code=0)
 
 
 class NutsRegionLevel1AutocompleteView(NutsRegionAutocompleteView):
     def hook_queryset(self, queryset):
-        return queryset.filter(levl_code=1)
+        return super().hook_queryset(queryset).filter(levl_code=1)
 
 
 class NutsRegionLevel2AutocompleteView(NutsRegionAutocompleteView):
     def hook_queryset(self, queryset):
-        return queryset.filter(levl_code=2)
+        return super().hook_queryset(queryset).filter(levl_code=2)
 
 
 class NutsRegionLevel3AutocompleteView(NutsRegionAutocompleteView):
     def hook_queryset(self, queryset):
-        return queryset.filter(levl_code=3)
+        return super().hook_queryset(queryset).filter(levl_code=3)
 
 
 class RegionOfLauAutocompleteView(UserCreatedObjectAutocompleteView):
@@ -1516,7 +1520,9 @@ class NutsRegionPedigreeAPI(APIView):
         if request.query_params["direction"] == "children":
             for lvl in range(instance.levl_code + 1, 4):
                 qs = NutsRegion.objects.filter(
-                    levl_code=lvl, nuts_id__startswith=instance.nuts_id
+                    levl_code=lvl,
+                    nuts_id__startswith=instance.nuts_id,
+                    version=instance.version_id,
                 )
                 serializer = NutsRegionOptionSerializer(qs, many=True)
                 data[f"id_level_{lvl}"] = serializer.data
@@ -1567,7 +1573,9 @@ class NutsAndLauCatchmentPedigreeAPI(APIView):
             for lvl in range(instance.levl_code + 1, 4):
                 # Prefetch needed: serializer accesses region_ptr.catchment_set in get_id
                 qs = NutsRegion.objects.filter(
-                    levl_code=lvl, nuts_id__startswith=instance.nuts_id
+                    levl_code=lvl,
+                    nuts_id__startswith=instance.nuts_id,
+                    version=instance.version_id,
                 ).prefetch_related("region_ptr__catchment_set")
                 serializer = NutsRegionCatchmentOptionSerializer(qs, many=True)
                 data[f"id_level_{lvl}"] = serializer.data

--- a/maps/viewsets.py
+++ b/maps/viewsets.py
@@ -2,13 +2,14 @@ import hashlib
 
 from django.db.models import Count, Max, Min
 from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
 from utils.viewsets import AutoPermModelViewSet
 
 from .filters import CatchmentFilterSet, RegionFilterSet
 from .mixins import CachedGeoJSONMixin, get_unbounded_geojson_rejection_response
-from .models import Catchment, Location, NutsRegion, Region
+from .models import Catchment, Location, NutsRegion, NutsVintage, Region
 from .serializers import (
     CatchmentGeoFeatureModelSerializer,
     CatchmentModelSerializer,
@@ -154,11 +155,30 @@ class NutsRegionViewSet(CachedGeoJSONMixin, AutoPermModelViewSet):
         "version": None,
     }
 
+    def get_vintage(self):
+        """The vintage this request is scoped to; the current one by default."""
+        label = self.request.query_params.get("version")
+        if not label:
+            return NutsVintage.current()
+        vintage = NutsVintage.resolve(label)
+        if vintage is None:
+            raise ValidationError(
+                {"version": f"Unknown NUTS vintage '{label}'."},
+            )
+        return vintage
+
+    def get_queryset(self):
+        return super().get_queryset().in_vintage(self.get_vintage())
+
     def get_cache_key(self, request):
         filters = request.query_params.dict()
-        level = filters.get("levl_code")
-        parent_id = filters.get("parent_id")
-        return get_nuts_region_cache_key(level, parent_id, filters)
+        vintage = self.get_vintage()
+        return get_nuts_region_cache_key(
+            level=filters.get("levl_code"),
+            parent_id=filters.get("parent_id"),
+            filters=filters,
+            version=vintage.year if vintage else None,
+        )
 
     def get_serializer_class(self):
         if self.action == "geojson":

--- a/maps/viewsets.py
+++ b/maps/viewsets.py
@@ -176,6 +176,7 @@ class NutsRegionViewSet(CachedGeoJSONMixin, AutoPermModelViewSet):
         return get_nuts_region_cache_key(
             level=filters.get("levl_code"),
             parent_id=filters.get("parent_id"),
+            nuts_id=filters.get("id"),
             filters=filters,
             version=vintage.year if vintage else None,
         )


### PR DESCRIPTION
Follow-up to #301 (stacked on its branch), PR 2 of the plan in #299. Fixes the duplicate-feature problem found in runtime testing: `GET /maps/api/nuts_region/geojson/?levl_code=3&cntr_code=DE` returned one `DE111` row *per vintage*, so map layers would draw overlapping duplicate features and pickers would list each territory twice as soon as NUTS 2024 is loaded.

## What changes

`NutsRegion.objects` gains `in_vintage(vintage=None)`, defaulting to `NutsVintage.current()`. Everything user-facing goes through it:

| Surface | Before | After |
|---|---|---|
| `NutsRegionViewSet` list/geojson | all vintages | current, or `?version=2024`; unknown vintage → 400 |
| GeoJSON cache key | no vintage | `nuts_geojson:vintage:<year>:…` |
| NUTS level pickers (`NutsRegionFilterSet`) | all vintages | current, resolved per request via a callable queryset |
| `nutsregion-autocomplete-level{0..3}` | all vintages | current |
| `NutsRegion.pedigree`, `NutsRegionPedigreeAPI`, `NutsAndLauCatchmentPedigreeAPI` | `nuts_id__startswith` across vintages | same vintage as the region asked about |
| `set_country` | first spatially-containing level-0 row of *any* vintage | current vintage only (was non-deterministic once vintages overlap) |

Hierarchy queries deliberately follow the *region's own* vintage rather than the current one, so drilling into a 2024 region keeps returning 2024 children.

Also fixes a latent bug in the cache key call: `get_nuts_region_cache_key(level, parent_id, filters)` passed `filters` into the `nuts_id` positional slot, collapsing every filtered request onto an `id:`-style key. It is now called with keywords.

Not in scope: the Waste Atlas `nuts_id__startswith` catchment filter (catchments point at specific NutsRegion rows, so it only becomes ambiguous once per-vintage catchments exist) and the map JS payloads, which join on `nuts_id` but receive an already-scoped response.

## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Verification

- [x] Focused tests or checks were run.
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed. (none changed)
- [x] No secrets, raw data, or production-only configuration are included.

New `maps/tests/test_vintage_scoping.py` builds `DE111` and `DE` in both NUTS 2021 (current) and NUTS 2024 and asserts each surface returns exactly one row, that `?version=2024` returns the 2024 geometry, that an unheld vintage is rejected, that cache keys differ per vintage, and that a country whose level-0 row exists in both vintages resolves via the current one.

```
brit-worktree-test . -- maps.tests.test_vintage_scoping        # 9 tests, OK
brit-worktree-test . -- maps                                   # 719 tests, OK
brit-worktree-test . -- sources.waste_collection inventories   # 2155 tests, OK
ruff format / ruff check maps, makemigrations --check          # clean
```

Link to Devin session: https://app.devin.ai/sessions/0c030e864261485c96a2f56ea3aa0322
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->