### PR TITLE
fix: keep collections with uncountable frequency in filtered lists

### DIFF
--- a/sources/waste_collection/filters.py
+++ b/sources/waste_collection/filters.py
@@ -343,13 +343,21 @@ class CollectionsPerYearFilter(NullableRangeFilter):
     def apply_range(self, qs, value_slice: slice, include_nulls: bool):
         freqs = CollectionFrequency.objects.annotate(
             collection_count=Sum("collectioncountoptions__standard")
-        ).filter(
-            collection_count__gte=value_slice.start,
-            collection_count__lte=value_slice.stop,
         )
-        filtered = qs.filter(frequency__in=freqs)
+        filtered = qs.filter(
+            frequency__in=freqs.filter(
+                collection_count__gte=value_slice.start,
+                collection_count__lte=value_slice.stop,
+            )
+        )
         if include_nulls:
-            filtered = filtered | qs.filter(frequency__isnull=True)
+            # A frequency without collection count options yields no countable
+            # value, so those collections count as null just like collections
+            # without any frequency at all.
+            filtered = filtered | qs.filter(
+                Q(frequency__isnull=True)
+                | Q(frequency__in=freqs.filter(collection_count__isnull=True))
+            )
         return filtered
 
 

--- a/sources/waste_collection/tests/test_filters.py
+++ b/sources/waste_collection/tests/test_filters.py
@@ -106,6 +106,9 @@ class CollectionsPerYearFilterTestCase(TestCase):
         seasonal_frequency = CollectionFrequency.objects.create(
             name="Seasonal Frequency"
         )
+        uncountable_frequency = CollectionFrequency.objects.create(
+            name="Frequency Without Count Options"
+        )
 
         CollectionCountOptions.objects.create(
             frequency=continuous_frequency, season=whole_year, standard=35, option_1=70
@@ -127,6 +130,9 @@ class CollectionsPerYearFilterTestCase(TestCase):
             name="Collection 3", frequency=seasonal_frequency
         )
         cls.collection4 = Collection.objects.create(name="Collection 4")
+        cls.collection5 = Collection.objects.create(
+            name="Collection 5", frequency=uncountable_frequency
+        )
 
     def test_filter_by_collections_per_year(self):
         filter_ = CollectionsPerYearFilter()
@@ -145,9 +151,19 @@ class CollectionsPerYearFilterTestCase(TestCase):
         filter_ = CollectionsPerYearFilter()
         qs = filter_.filter(Collection.objects.all(), (slice(52, 100), True))
         expected = Collection.objects.filter(
-            pk__in=[self.collection3.pk, self.collection4.pk]
+            pk__in=[self.collection3.pk, self.collection4.pk, self.collection5.pk]
         )
         self.assertQuerySetEqual(qs, expected, ordered=False)
+
+    def test_frequency_without_count_options_is_treated_as_null(self):
+        filter_ = CollectionsPerYearFilter()
+        qs = filter_.filter(Collection.objects.all(), (slice(0, 100), True))
+        self.assertIn(self.collection5, qs)
+
+    def test_frequency_without_count_options_is_excluded_without_nulls(self):
+        filter_ = CollectionsPerYearFilter()
+        qs = filter_.filter(Collection.objects.all(), (slice(0, 100), False))
+        self.assertNotIn(self.collection5, qs)
 
 
 class ConnectionRateFilterTestCase(TestCase):


### PR DESCRIPTION
## Summary

- `CollectionsPerYearFilter.apply_range` annotated `collection_count=Sum("collectioncountoptions__standard")` on frequencies, but the `include_nulls` branch only caught `frequency__isnull=True`. Frequencies that exist but have no `CollectionCountOptions` rows (or rows with `standard=NULL`) produced a NULL aggregate and silently fell out of the queryset, so their collections vanished from every filtered list, map and export.
- The fix includes frequencies where `collection_count IS NULL` in the nulls branch, mirroring the pattern already used in `NullableCollectionPropertyValueRangeFilter`.
- 286 collections in review scope (plus 4 published) were affected. A companion data fix in `BRIT-data` repairs the underlying frequencies so `collections_per_year` is actually populated.

## Test plan

- [x] New `CollectionsPerYearFilterTestCase` fixtures include a frequency without `CollectionCountOptions` and a collection pointing to it.
- [x] `test_filter_by_collections_per_year_with_nulls` now expects the uncountable-frequency collection to appear when `include_nulls=True`.
- [x] `test_frequency_without_count_options_is_treated_as_null` — collection appears in range `[0, 100]` with nulls.
- [x] `test_frequency_without_count_options_is_excluded_without_nulls` — collection is excluded when `include_nulls=False`.
- [x] Full `sources.waste_collection.tests.test_filters` (47 tests) passes.
- [x] Full `sources.waste_collection.tests` suite (1887 tests, 379 skipped) passes — no regressions.

Generated with [Devin](https://devin.ai)