### PR TITLE
Fix empty frequency season form save

### DIFF
--- a/sources/waste_collection/forms.py
+++ b/sources/waste_collection/forms.py
@@ -314,6 +314,9 @@ class CollectionSeasonForm(SimpleForm):
         return cleaned_data
 
     def save(self):
+        if not self.cleaned_data:
+            return None
+
         self.instance, _ = CollectionSeason.objects.get_or_create(
             distribution=self.cleaned_data["distribution"],
             first_timestep=self.cleaned_data["first_timestep"],
@@ -341,6 +344,8 @@ class CollectionSeasonFormSet(M2MInlineFormSet):
         child_objects = super().save(commit=commit)
 
         for form in self.forms:
+            if not form.cleaned_data:
+                continue
             options = CollectionCountOptions.objects.get(
                 frequency=self.parent_object, season=form.instance
             )

--- a/sources/waste_collection/tests/test_views.py
+++ b/sources/waste_collection/tests/test_views.py
@@ -713,6 +713,41 @@ class CollectionFrequencyCRUDViewsTestCase(
         self.assertIsNone(self.options_2.option_2)
         self.assertIsNone(self.options_2.option_3)
 
+    def test_update_ignores_unchanged_empty_extra_season_form(self):
+        frequency = CollectionFrequency.objects.create(
+            owner=self.owner_user,
+            name="Frequency without a schedule",
+            type="Fixed-Seasonal",
+        )
+        self.client.force_login(self.owner_user)
+        data = {
+            "name": "Updated frequency without a schedule",
+            "type": "Fixed-Seasonal",
+            "description": "",
+            "form-TOTAL_FORMS": "1",
+            "form-INITIAL_FORMS": "0",
+            "form-MIN_NUM_FORMS": "0",
+            "form-MAX_NUM_FORMS": "1000",
+            "form-0-distribution": str(self.distribution.pk),
+            "form-0-first_timestep": "",
+            "form-0-last_timestep": "",
+            "form-0-standard_cadence": "",
+            "form-0-standard": "",
+            "form-0-option_1_cadence": "",
+            "form-0-option_1": "",
+            "form-0-option_2_cadence": "",
+            "form-0-option_2": "",
+            "form-0-option_3_cadence": "",
+            "form-0-option_3": "",
+        }
+
+        response = self.client.post(self.get_update_url(frequency.pk), data)
+
+        self.assertEqual(response.status_code, 302)
+        frequency.refresh_from_db()
+        self.assertEqual(frequency.name, "Updated frequency without a schedule")
+        self.assertFalse(frequency.seasons.exists())
+
 
 # ----------- CollectionPropertyValue CRUD -----------------------------------------------------------------------------
 # ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- Ignore unchanged empty extra season forms when saving a collection frequency.
- Skip count-option persistence for those empty forms.
- Add an endpoint-level regression test matching the submitted update payload.

## Why

Django correctly treats an unchanged extra form as empty and leaves its `cleaned_data` dictionary empty. The custom season formset save path nevertheless called `CollectionSeasonForm.save()`, which indexed `cleaned_data["distribution"]` and raised a `KeyError`.

## Impact

Updating a collection frequency no longer returns a server error when the submitted formset contains a blank extra season row with only the hidden default distribution value. Populated season rows continue to save normally.

## Validation

- Confirmed the regression test fails with the original `KeyError` before the fix.
- Focused endpoint regression test: 1 passed.
- Nearby collection-season formset and frequency update tests: 8 passed.
- Ruff and Ruff format pre-commit hooks passed.