### PR TITLE
fix: normalize Waste Atlas fallback amount types

### DIFF
--- a/sources/waste_collection/tests/test_views.py
+++ b/sources/waste_collection/tests/test_views.py
@@ -6305,7 +6305,7 @@ class DerivedValuesTestCase(TestCase):
             col_to_cid={collection.pk: catchment.pk},
             catchment_ids=[catchment.pk],
         )
-        self.assertEqual(amounts[catchment.pk], Decimal("2.6"))
+        self.assertEqual(amounts[catchment.pk], 2.6)
 
     def test_amounts_fallback_does_not_use_population_from_another_year(self):
         collection, catchment = self._create_collection(

--- a/sources/waste_collection/tests/test_viewsets.py
+++ b/sources/waste_collection/tests/test_viewsets.py
@@ -3864,6 +3864,116 @@ class OrganicAmountViewSetTests(APITestCase):
         self.assertIsNone(by_catchment[self.catchment_residual_only.id]["ratio"])
 
 
+@override_settings(
+    WASTE_COLLECTION_SPECIFIC_WASTE_PROPERTY_ID=None,
+    WASTE_COLLECTION_TOTAL_WASTE_PROPERTY_ID=None,
+    WASTE_COLLECTION_SPECIFIC_WASTE_UNIT_ID=None,
+    WASTE_COLLECTION_TOTAL_WASTE_UNIT_ID=None,
+    WASTE_COLLECTION_POPULATION_ATTRIBUTE_ID=None,
+    WASTE_COLLECTION_SPECIFIC_WASTE_PROPERTY_NAME="specific waste collected [ratio-type-test]",
+    WASTE_COLLECTION_TOTAL_WASTE_PROPERTY_NAME="total waste collected [ratio-type-test]",
+    WASTE_COLLECTION_SPECIFIC_WASTE_UNIT_NAME="kg/(cap.*a) [ratio-type-test]",
+    WASTE_COLLECTION_TOTAL_WASTE_UNIT_NAME="Mg/a [ratio-type-test]",
+    WASTE_COLLECTION_POPULATION_ATTRIBUTE_NAME="Population [ratio-type-test]",
+)
+class WasteRatioMixedNumericTypesTests(APITestCase):
+    """Regression tests for ratios combining direct and fallback amounts."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.specific_property = Property.objects.create(
+            name="specific waste collected [ratio-type-test]"
+        )
+        cls.total_property = Property.objects.create(
+            name="total waste collected [ratio-type-test]"
+        )
+        cls.specific_unit = Unit.objects.create(name="kg/(cap.*a) [ratio-type-test]")
+        cls.total_unit = Unit.objects.create(name="Mg/a [ratio-type-test]")
+        cls.population_attribute = RegionProperty.objects.create(
+            name="Population [ratio-type-test]",
+            unit="cap",
+        )
+
+        bio_category, _ = WasteCategory.objects.get_or_create(name="Biowaste")
+        residual_category, _ = WasteCategory.objects.get_or_create(
+            name="Residual waste"
+        )
+        collection_system, _ = CollectionSystem.objects.get_or_create(
+            name="Door to door"
+        )
+        region = Region.objects.create(name="Ratio Type Region", country="DE")
+        cls.catchment = CollectionCatchment.objects.create(
+            name="Ratio Type Catchment",
+            region=region,
+        )
+        bio_collection = Collection.objects.create(
+            name="Ratio Type Biowaste",
+            catchment=cls.catchment,
+            waste_category=bio_category,
+            collection_system=collection_system,
+            valid_from=date(2024, 1, 1),
+            publication_status="published",
+        )
+        residual_collection = Collection.objects.create(
+            name="Ratio Type Residual",
+            catchment=cls.catchment,
+            waste_category=residual_category,
+            collection_system=collection_system,
+            valid_from=date(2024, 1, 1),
+            publication_status="published",
+        )
+
+        RegionAttributeValue.objects.create(
+            name="Ratio Type Population",
+            region=region,
+            property=cls.population_attribute,
+            date=date(2024, 1, 1),
+            value=1000,
+        )
+        CollectionPropertyValue.objects.bulk_create(
+            [
+                CollectionPropertyValue(
+                    name="Ratio Type Biowaste Total",
+                    collection=bio_collection,
+                    property=cls.total_property,
+                    unit=cls.total_unit,
+                    year=2024,
+                    average=100.0,
+                    publication_status="published",
+                ),
+                CollectionPropertyValue(
+                    name="Ratio Type Residual Specific",
+                    collection=residual_collection,
+                    property=cls.specific_property,
+                    unit=cls.specific_unit,
+                    year=2024,
+                    average=50.0,
+                    publication_status="published",
+                ),
+            ]
+        )
+
+    def setUp(self):
+        clear_derived_value_config_cache()
+
+    def tearDown(self):
+        clear_derived_value_config_cache()
+
+    def test_waste_ratio_combines_fallback_and_direct_amounts(self):
+        response = self.client.get(
+            "/waste_collection/api/waste-atlas/waste-ratio/",
+            {"country": "DE", "year": 2024},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        row = next(
+            item for item in response.data if item["catchment_id"] == self.catchment.id
+        )
+        self.assertEqual(row["bio_amount"], 100.0)
+        self.assertEqual(row["residual_amount"], 50.0)
+        self.assertAlmostEqual(row["ratio"], 2 / 3)
+
+
 class SouthTyrolCollectionPointTests(APITestCase):
     """Regression tests for South Tyrol collection-point atlas fix.
 

--- a/sources/waste_collection/waste_atlas/viewsets.py
+++ b/sources/waste_collection/waste_atlas/viewsets.py
@@ -1838,7 +1838,7 @@ def _amounts_for_year(
             continue
         pop = region_pop.get(region_id)
         if pop and pop > 0:
-            result[cid] = convert_total_to_specific(total_mg, pop, ndigits=1)
+            result[cid] = float(convert_total_to_specific(total_mg, pop, ndigits=1))
             value_sources[cid] = "cpv"
     if include_metadata:
         return result, value_sources, acpv_group_keys
@@ -2081,7 +2081,9 @@ def _get_green_waste_collection_amount(country, year, nuts_prefixes=(), user=Non
                     continue
                 pop = region_pop.get(region_id)
                 if pop and pop > 0:
-                    amounts[cid] = convert_total_to_specific(total_mg, pop, ndigits=1)
+                    amounts[cid] = float(
+                        convert_total_to_specific(total_mg, pop, ndigits=1)
+                    )
 
     data = []
     for cid, row in best.items():


### PR DESCRIPTION
## Summary

- normalize total-waste/population fallback amounts to `float` in both collection and green-waste atlas paths
- prevent mixed `Decimal`/`float` arithmetic from crashing waste-ratio and organic amount calculations
- add an endpoint regression test combining fallback-derived biowaste with directly stored residual waste
- align the existing internal fallback assertion with the helper's declared float contract

## Root cause

Direct and aggregated property values come from `FloatField` columns, while `convert_total_to_specific()` intentionally performs exact conversion using `Decimal`. The Waste Atlas fallback stored that `Decimal` directly in maps otherwise containing floats. A catchment with fallback-derived biowaste and directly stored residual waste therefore raised `TypeError` while evaluating `b + r`, returning HTTP 500 from `/waste_collection/api/waste-atlas/waste-ratio/`.

## Impact

Waste Atlas ratio and organic amount endpoints can now combine direct, aggregated, and total/population-derived amounts consistently without numeric-type errors.

## Validation

- Confirmed the new regression test failed before the fix with the production `Decimal + float` traceback.
- Focused regression targets: 2 passed.
- Full inferred waste-collection scope on current `main`: 1,884 passed, 379 skipped.
- Ruff check on all changed files: passed.
- Commit hooks (`ruff`, `ruff format`): passed.