### PR TITLE
ci: run tests non-interactively

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,4 +132,4 @@ jobs:
           POSTGRES_PORT: 5432
           REDIS_URL: redis://localhost:6379/0
           SECRET_KEY: ci-test-key-not-secret
-        run: uv run python manage.py test --settings=brit.settings.testrunner --parallel 2
+        run: uv run python manage.py test --settings=brit.settings.testrunner --parallel 2 --noinput


### PR DESCRIPTION
## What changed

- Added Django's `--noinput` flag to the GitHub Actions test command.

## Why

CI cannot answer interactive prompts. If an old test database unexpectedly exists, Django should replace it automatically instead of waiting for input or failing on EOF.

## Impact

Clean CI runs behave as before. Recovery from a stale test database is now non-interactive and consistent with the documented local test command.

## Validation

- Confirmed Django's test command recognizes `--noinput` / `--no-input` inside the `web` container.
- Ran `git diff --check`.