### PR TITLE
fix: warn on custom catchments with negligible spatial overlap to tree parent

### DIFF
--- a/maps/signals.py
+++ b/maps/signals.py
@@ -188,6 +188,50 @@ def set_lau_catchment_parent(sender, instance, created, **kwargs):
         Catchment.objects.filter(pk=instance.pk).update(parent_id=correct_parent.pk)
 
 
+@receiver(post_save, sender=Catchment)
+def warn_custom_catchment_parent_mismatch(sender, instance, **kwargs):
+    """Warn when a custom catchment barely overlaps its tree parent.
+
+    Custom catchments (e.g. waste-management associations) are user-defined
+    areas whose tree ``parent`` is set manually — typically via the admin.
+    Unlike the NUTS / LAU / administrative hierarchy, the tree parent does
+    not guarantee spatial containment.  A custom catchment may legitimately
+    *partially* overlap its parent, but a negligible overlap (below 1% of
+    the smaller geometry's area — usually a coordinate sliver) means the
+    parent assignment is almost certainly wrong and will cause unrelated
+    collections to surface in ``downstream_collections`` lookups.
+
+    This signal logs a warning (non-blocking) so that data curators are
+    alerted to the mismatch without preventing the save.
+    """
+    if instance.type != "custom":
+        return
+    if instance.parent_id is None:
+        return
+
+    own_geom = instance.geom
+    parent_geom = instance.parent.geom
+    if own_geom is None or parent_geom is None:
+        return
+
+    smaller_area = min(own_geom.area, parent_geom.area)
+    if smaller_area == 0:
+        return
+    overlap_pct = own_geom.intersection(parent_geom).area / smaller_area * 100
+    if overlap_pct < 1.0:
+        logger.warning(
+            "Custom catchment %r (id=%s) has only %.4f%% spatial overlap with "
+            "its tree parent %r (id=%s). The parent assignment is likely "
+            "incorrect and may cause unrelated collections to appear in "
+            "downstream lookups.",
+            instance.name,
+            instance.pk,
+            overlap_pct,
+            instance.parent.name,
+            instance.parent_id,
+        )
+
+
 @receiver(post_save, sender=LauRegion)
 @receiver(post_delete, sender=LauRegion)
 def invalidate_lau_region_cache(sender, instance, **kwargs):

--- a/maps/tests/test_models.py
+++ b/maps/tests/test_models.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.contrib.gis.geos import GEOSGeometry, Point
 from django.db.models import QuerySet
 from django.test import TestCase
@@ -383,6 +385,100 @@ class LauCatchmentParentSignalTestCase(TestCase):
         self.lau_catchment.refresh_from_db()
         descendants = list(self.nuts3_catchment.descendants(include_self=True))
         self.assertIn(self.lau_catchment, descendants)
+
+
+class CustomCatchmentParentMismatchSignalTestCase(TestCase):
+    """A warning is logged when a custom catchment has negligible spatial
+    overlap (< 1% of the smaller geometry's area) with its tree parent.
+
+    Custom catchments (e.g. waste-management associations) may legitimately
+    partially overlap their parent, but a sliver-level overlap means the
+    parent assignment is wrong.  The signal warns non-blocking so the save
+    still succeeds.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.parent_region = Region.objects.create(
+            name="Parent Region",
+            country="DE",
+            type="nuts",
+            borders=GeoPolygon.objects.create(
+                geom=GEOSGeometry(
+                    "MULTIPOLYGON(((0 0, 0 1, 1 1, 1 0, 0 0)))", srid=4326
+                )
+            ),
+        )
+        cls.parent_catchment = Catchment.objects.create(
+            name="Parent NUTS",
+            type="nuts",
+            region=cls.parent_region,
+        )
+
+    def test_warning_logged_when_custom_catchment_has_negligible_overlap(self):
+        outside_region = Region.objects.create(
+            name="Outside Region",
+            country="DE",
+            type="custom",
+            borders=GeoPolygon.objects.create(
+                geom=GEOSGeometry(
+                    "MULTIPOLYGON(((2 2, 2 3, 3 3, 3 2, 2 2)))", srid=4326
+                )
+            ),
+        )
+        with self.assertLogs("maps.signals", level="WARNING") as cm:
+            Catchment.objects.create(
+                name="Outside Custom",
+                type="custom",
+                parent=self.parent_catchment,
+                region=outside_region,
+            )
+        self.assertIn("spatial overlap with", "\n".join(cm.output))
+
+    def test_no_warning_when_custom_catchment_substantially_overlaps_parent(self):
+        inside_region = Region.objects.create(
+            name="Inside Region",
+            country="DE",
+            type="custom",
+            borders=GeoPolygon.objects.create(
+                geom=GEOSGeometry(
+                    "MULTIPOLYGON(((0.1 0.1, 0.1 0.9, 0.9 0.9, 0.9 0.1, 0.1 0.1)))",
+                    srid=4326,
+                )
+            ),
+        )
+        with self.assertLogs("maps.signals", level="WARNING") as cm:
+            Catchment.objects.create(
+                name="Inside Custom",
+                type="custom",
+                parent=self.parent_catchment,
+                region=inside_region,
+            )
+            # assertLogs requires at least one log record; emit a dummy one
+            # so the assertion doesn't fail when no warning is produced.
+            logging.getLogger("maps.signals").warning("dummy")
+        self.assertNotIn("spatial overlap with", "\n".join(cm.output))
+
+    def test_no_warning_for_non_custom_catchment(self):
+        admin_region = Region.objects.create(
+            name="Admin Region",
+            country="DE",
+            type="administrative",
+            borders=GeoPolygon.objects.create(
+                geom=GEOSGeometry(
+                    "MULTIPOLYGON(((2 2, 2 3, 3 3, 3 2, 2 2)))", srid=4326
+                )
+            ),
+        )
+        with self.assertLogs("maps.signals", level="WARNING") as cm:
+            Catchment.objects.create(
+                name="Admin Child",
+                type="administrative",
+                parent=self.parent_catchment,
+                region=admin_region,
+            )
+            logging.getLogger("maps.signals").warning("dummy")
+        self.assertNotIn("spatial overlap with", "\n".join(cm.output))
 
 
 class NutsRegionTestCase(TestCase):


### PR DESCRIPTION
## Summary

- Adds a `post_save` signal (`warn_custom_catchment_parent_mismatch`) that logs a warning when a custom catchment's spatial overlap with its tree parent is below 1% of the smaller geometry's area — catching coordinate-sliver mismatches that cause unrelated collections to surface in `downstream_collections` lookups
- The warning is non-blocking; saves still succeed
- Existing mismatched data was fixed via a one-off SQL query reassigning 4 custom catchments (ZAOE, EGN, ROVA, Irado) to their correct NUTS parents at ~99.7%+ overlap

### Root cause

Custom catchments (e.g. waste-management associations) have their tree `parent` set manually via the Django admin. Unlike the NUTS/LAU/administrative hierarchy, this does not guarantee spatial containment. When ZAOE's tree parent was set to Dresden NUTS3 (DED21) — which ZAOE barely touches at 0.0014% overlap — its collections appeared when filtering for Dresden, Kreisfreie Stadt.

#### Test plan

- [x] `test_warning_logged_when_custom_catchment_has_negligible_overlap` — warning fires for 0% overlap
- [x] `test_no_warning_when_custom_catchment_substantially_overlaps_parent` — no warning for ~100% overlap
- [x] `test_no_warning_for_non_custom_catchment` — signal only applies to custom catchments
- [x] Full `maps` test suite passes (695 tests, 0 failures)
- [x] Ruff check and format pass

Generated with [Devin](https://devin.ai)