### PR TITLE
fix: add review list views and routes for Author and Licence

### DIFF
--- a/bibliography/tests/test_views.py
+++ b/bibliography/tests/test_views.py
@@ -440,6 +440,89 @@ class SourceReviewListRegressionTest(ViewWithPermissionsTestCase):
         )
 
 
+class AuthorReviewListRegressionTest(ViewWithPermissionsTestCase):
+    member_permissions = ["can_moderate_author"]
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.review_author = Author.objects.create(
+            owner=cls.outsider,
+            first_names="Review",
+            last_names="Author",
+            publication_status="review",
+        )
+
+    def test_review_list_is_reachable_for_moderator(self):
+        self.client.force_login(self.member)
+
+        response = self.client.get(reverse("author-list-review"), follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.redirect_chain,
+            [(f"{reverse('author-list-review')}?scope=review", 302)],
+        )
+        self.assertContains(response, str(self.review_author))
+
+    def test_private_list_uses_dedicated_review_route_for_scope_toggle(self):
+        self.client.force_login(self.member)
+
+        response = self.client.get(reverse("author-list-owned"), {"scope": "private"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.context["review_representation_url"],
+            reverse("author-list-review"),
+        )
+        self.assertContains(
+            response,
+            f'href="{reverse("author-list-review")}?scope=review"',
+            html=False,
+        )
+
+
+class LicenceReviewListRegressionTest(ViewWithPermissionsTestCase):
+    member_permissions = ["can_moderate_licence"]
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.review_licence = Licence.objects.create(
+            owner=cls.outsider,
+            name="Review Licence",
+            publication_status="review",
+        )
+
+    def test_review_list_is_reachable_for_moderator(self):
+        self.client.force_login(self.member)
+
+        response = self.client.get(reverse("licence-list-review"), follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.redirect_chain,
+            [(f"{reverse('licence-list-review')}?scope=review", 302)],
+        )
+        self.assertContains(response, self.review_licence.name)
+
+    def test_private_list_uses_dedicated_review_route_for_scope_toggle(self):
+        self.client.force_login(self.member)
+
+        response = self.client.get(reverse("licence-list-owned"), {"scope": "private"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.context["review_representation_url"],
+            reverse("licence-list-review"),
+        )
+        self.assertContains(
+            response,
+            f'href="{reverse("licence-list-review")}?scope=review"',
+            html=False,
+        )
+
+
 class SourceCheckUrlViewTestCase(ViewWithPermissionsTestCase):
     member_permissions = ["can_moderate_source"]
 

--- a/bibliography/urls.py
+++ b/bibliography/urls.py
@@ -12,6 +12,7 @@ from .views import (
     AuthorPrivateListView,
     AuthorPublishedListView,
     AuthorQuickCreateView,
+    AuthorReviewListView,
     AuthorUpdateView,
     BibliographyExplorerView,
     LicenceAutocompleteView,
@@ -23,6 +24,7 @@ from .views import (
     LicenceModalUpdateView,
     LicencePrivateListView,
     LicencePublishedListView,
+    LicenceReviewListView,
     LicenceUpdateView,
     SourceAutocompleteView,
     SourceBibtexArticleImportView,
@@ -50,6 +52,11 @@ urlpatterns = [
     ),
     path("authors/", AuthorPublishedListView.as_view(), name="author-list"),
     path("authors/user/", AuthorPrivateListView.as_view(), name="author-list-owned"),
+    path(
+        "authors/review/",
+        AuthorReviewListView.as_view(),
+        name="author-list-review",
+    ),
     path("authors/create/", AuthorCreateView.as_view(), name="author-create"),
     path(
         "authors/create/modal/",
@@ -92,6 +99,11 @@ urlpatterns = [
         "licences/user/",
         LicencePrivateListView.as_view(),
         name="licence-list-owned",
+    ),
+    path(
+        "licences/review/",
+        LicenceReviewListView.as_view(),
+        name="licence-list-review",
     ),
     path("licences/create/", LicenceCreateView.as_view(), name="licence-create"),
     path(

--- a/bibliography/views.py
+++ b/bibliography/views.py
@@ -87,6 +87,13 @@ class AuthorPrivateListView(PrivateObjectFilterView):
     ordering = "last_names"
 
 
+class AuthorReviewListView(ReviewObjectFilterView):
+    model = Author
+    filterset_class = AuthorFilterSet
+    dashboard_url = reverse_lazy("bibliography-explorer")
+    ordering = "last_names"
+
+
 class AuthorCreateView(UserCreatedObjectCreateView):
     form_class = AuthorModelForm
     permission_required = "bibliography.add_author"
@@ -152,6 +159,12 @@ class LicencePublishedListView(PublishedObjectFilterView):
 
 
 class LicencePrivateListView(PrivateObjectFilterView):
+    model = Licence
+    filterset_class = LicenceListFilter
+    dashboard_url = reverse_lazy("bibliography-explorer")
+
+
+class LicenceReviewListView(ReviewObjectFilterView):
     model = Licence
     filterset_class = LicenceListFilter
     dashboard_url = reverse_lazy("bibliography-explorer")


### PR DESCRIPTION
## Summary
- Authors and licences under review never appeared in their list views because the bibliography module only wired up a dedicated `ReviewObjectFilterView` and `<model>-list-review` route for `Source`.
- The `scope=review` query param alone cannot override a view's class-level `list_type`, so the published-only queryset intersected with `scope=review` yielded an empty list, hiding review-status items from moderators (e.g. flexibi, phillipp).
- Adds `AuthorReviewListView` and `LicenceReviewListView` (mirroring `SourceReviewFilterView`) and registers `authors/review/` and `licences/review/` routes so the scope toggle navigates to a real review-scoped view.
- Adds regression tests equivalent to `SourceReviewListRegressionTest` for both Author and Licence.

#### Test plan
- [x] `brit-worktree-test author-review-list -- bibliography.tests.test_views.AuthorReviewListRegressionTest bibliography.tests.test_views.LicenceReviewListRegressionTest` → 4 passed (initially 4 errors with `NoReverseMatch`)
- [x] `brit-worktree-test author-review-list -- bibliography.tests.test_views` → 304 passed, 16 skipped
- [x] `ruff check` and `ruff format --check` on changed files → clean

Generated with [Devin](https://devin.ai)