### PR TITLE
refactor: derive waste-atlas export file names from map set and theme

### DIFF
--- a/sources/waste_collection/tests/test_waste_atlas_configuration_views.py
+++ b/sources/waste_collection/tests/test_waste_atlas_configuration_views.py
@@ -349,3 +349,84 @@ class WasteAtlasMapConfigurationViewsTestCase(TestCase):
         self.assertEqual(rendered_config["exportLegendPlacement"], "top-left")
         self.assertEqual(rendered_config["exportLegendWidth"], 0.45)
         self.assertEqual(rendered_config["exportLegendColumns"], 2)
+
+
+class WasteAtlasExportFileNameTestCase(TestCase):
+    """Export file names must be derived globally from (map set, theme).
+
+    ``fileBase`` is the stem the choropleth renderer appends ``.svg``/``.png``
+    (and ``_change_<from>_<to>`` for change maps) to.  It must follow one
+    deterministic rule for every map page instead of being hand-set per page
+    or per stored configuration.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(
+            username="atlas-export-user",
+            password="secret",
+        )
+        atlas_group, _ = Group.objects.get_or_create(name="waste_atlas")
+        cls.user.groups.add(atlas_group)
+
+    # (route name, expected fileBase) covering generic, country, sub-national,
+    # multi-token selector sets and a theme only seeded for one region.
+    EXPECTED_FILE_BASES = (
+        ("waste-atlas-orga-level-map", "waste_atlas_orga_level"),
+        (
+            "waste-atlas-orga-level-italy-map",
+            "waste_atlas_it_orga_level",
+        ),
+        (
+            "waste-atlas-germany-collection-system-map",
+            "waste_atlas_de_collection_system",
+        ),
+        (
+            "waste-atlas-nrw-participation-policy-map",
+            "waste_atlas_de_nw_participation_policy",
+        ),
+        (
+            "waste-atlas-sweden-biowaste-collection-amount-map",
+            "waste_atlas_se_biowaste_collection_amount",
+        ),
+        (
+            "waste-atlas-south-tyrol-target-waste-category-map",
+            "waste_atlas_it_st_target_waste_category",
+        ),
+        (
+            "waste-atlas-orga-level-belgium-flanders-map",
+            "waste_atlas_be_fl_br_orga_level",
+        ),
+    )
+
+    def test_every_map_page_derives_a_deterministic_file_base(self):
+        self.client.force_login(self.user)
+        for route_name, expected in self.EXPECTED_FILE_BASES:
+            with self.subTest(route=route_name):
+                response = self.client.get(reverse(route_name))
+                self.assertEqual(response.status_code, 200)
+                rendered_config = _rendered_map_config(response)
+                self.assertEqual(rendered_config["fileBase"], expected)
+
+    def test_no_map_page_defines_a_manual_file_base_override(self):
+        """No page may carry a ``fileBase`` override; naming is global."""
+        for page in MAP_PAGES:
+            overrides = page.get("overrides") or {}
+            with self.subTest(route=page["name"]):
+                self.assertNotIn("fileBase", overrides)
+
+    def test_no_stored_configuration_carries_a_file_base(self):
+        """Stored configs must not keep a stale ``fileBase`` key."""
+        for config in WasteAtlasMapConfiguration.objects.all():
+            with self.subTest(key=config.key):
+                self.assertNotIn("fileBase", config.configuration)
+
+
+def _rendered_map_config(response):
+    match = re.search(
+        r'<script id="atlas-config" type="application/json">(.*?)</script>',
+        response.content.decode(),
+        re.S,
+    )
+    assert match is not None, "atlas-config script not rendered"
+    return json.loads(match.group(1))

--- a/sources/waste_collection/tests/test_waste_atlas_map_configs.py
+++ b/sources/waste_collection/tests/test_waste_atlas_map_configs.py
@@ -32,7 +32,6 @@ REQUIRED_CONFIG_KEYS = frozenset(
         "categories",
         "noDataColor",
         "legendTitle",
-        "fileBase",
     }
 )
 

--- a/sources/waste_collection/waste_atlas/migrations/0004_drop_file_base_from_map_configurations.py
+++ b/sources/waste_collection/waste_atlas/migrations/0004_drop_file_base_from_map_configurations.py
@@ -1,0 +1,35 @@
+"""Drop the obsolete ``fileBase`` key from stored map configurations.
+
+Export file names are now derived deterministically from each map page's
+map set and theme (see ``waste_atlas.templatetags.atlas_tags.export_file_base``),
+so the per-configuration ``fileBase`` value seeded by migrations 0002 and
+0003 is no longer read.  This migration strips it from every stored
+configuration so the column stays clean.
+"""
+
+from django.db import migrations
+
+
+def drop_file_base(apps, schema_editor):
+    configuration_model = apps.get_model(
+        "waste_atlas",
+        "WasteAtlasMapConfiguration",
+    )
+    for configuration in configuration_model.objects.all():
+        if "fileBase" in configuration.configuration:
+            configuration.configuration.pop("fileBase")
+            configuration.save(update_fields=["configuration"])
+
+
+def noop(apps, schema_editor):
+    """The original ``fileBase`` values are gone; restore is not meaningful."""
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("waste_atlas", "0003_seed_target_waste_category"),
+    ]
+
+    operations = [
+        migrations.RunPython(drop_file_base, noop),
+    ]

--- a/sources/waste_collection/waste_atlas/pages.py
+++ b/sources/waste_collection/waste_atlas/pages.py
@@ -167,7 +167,6 @@ MAP_PAGES = [
         "map/italy/administrative-level/",
         "waste-atlas-orga-level-italy-map",
         config_key="orga_level_eu",
-        overrides={"fileBase": "map29_orga_level_italy"},
     ),
     _page(
         "italy",
@@ -176,7 +175,6 @@ MAP_PAGES = [
         "map/italy/administrative-level/collections/",
         "waste-atlas-collection-orga-level-italy-map",
         config_key="collection_orga_level_eu",
-        overrides={"fileBase": "map29_collection_orga_level_italy"},
     ),
     _page(
         "italy",
@@ -270,7 +268,6 @@ MAP_PAGES = [
         "map/south-tyrol/administrative-level/",
         "waste-atlas-south-tyrol-orga-level-map",
         config_key="orga_level_eu",
-        overrides={"fileBase": "map29_orga_level_italy"},
     ),
     _page(
         "south_tyrol",
@@ -279,7 +276,6 @@ MAP_PAGES = [
         "map/south-tyrol/administrative-level/collections/",
         "waste-atlas-south-tyrol-collection-orga-level-map",
         config_key="collection_orga_level_eu",
-        overrides={"fileBase": "map29_collection_orga_level_italy"},
     ),
     _page(
         "south_tyrol",
@@ -464,7 +460,6 @@ MAP_PAGES = [
         "map/sweden/administrative-level/",
         "waste-atlas-orga-level-sweden-map",
         config_key="orga_level_eu",
-        overrides={"fileBase": "map30_orga_level_sweden"},
     ),
     _page(
         "sweden",
@@ -473,7 +468,6 @@ MAP_PAGES = [
         "map/sweden/administrative-level/collections/",
         "waste-atlas-collection-orga-level-sweden-map",
         config_key="collection_orga_level_eu",
-        overrides={"fileBase": "map30_collection_orga_level_sweden"},
     ),
     _page(
         "sweden",
@@ -495,7 +489,6 @@ MAP_PAGES = [
         "Primary collection system for kitchen waste",
         "map/sweden/collection-system/",
         "waste-atlas-sweden-collection-system-map",
-        overrides={"fileBase": "sweden_collection_system"},
     ),
     _page(
         "sweden",
@@ -503,7 +496,6 @@ MAP_PAGES = [
         "Connection rates for door-to-door biowaste collection",
         "map/sweden/connection-rate/",
         "waste-atlas-sweden-connection-rate-map",
-        overrides={"fileBase": "sweden_connection_rate"},
     ),
     _page(
         "sweden",
@@ -511,7 +503,6 @@ MAP_PAGES = [
         "Use of paper bags for biowaste collection",
         "map/sweden/paper-bags/",
         "waste-atlas-sweden-paper-bags-map",
-        overrides={"fileBase": "sweden_paper_bags"},
     ),
     _page(
         "sweden",
@@ -519,7 +510,6 @@ MAP_PAGES = [
         "Use of compostable plastic bags for biowaste collection",
         "map/sweden/plastic-bags/",
         "waste-atlas-sweden-plastic-bags-map",
-        overrides={"fileBase": "sweden_plastic_bags"},
     ),
     _page(
         "sweden",
@@ -527,7 +517,6 @@ MAP_PAGES = [
         "Accepted materials for collection aids",
         "map/sweden/collection-support/",
         "waste-atlas-sweden-collection-support-map",
-        overrides={"fileBase": "sweden_collection_support"},
     ),
     _page(
         "sweden",
@@ -536,7 +525,6 @@ MAP_PAGES = [
         "map/sweden/residual-collection-amount/",
         "waste-atlas-sweden-residual-collection-amount-map",
         overrides={
-            "fileBase": "sweden_residual_collection_amount",
             "exportLegendTitle": "Collected amount (kg / cap / a)",
         },
     ),
@@ -546,7 +534,6 @@ MAP_PAGES = [
         "Specifically collected amount of biowaste",
         "map/sweden/biowaste-collection-amount/",
         "waste-atlas-sweden-biowaste-collection-amount-map",
-        overrides={"fileBase": "sweden_biowaste_collection_amount"},
     ),
     _page(
         "sweden",
@@ -554,7 +541,6 @@ MAP_PAGES = [
         "Separation rate – Biowaste stream (%)",
         "map/sweden/waste-ratio/",
         "waste-atlas-sweden-waste-ratio-map",
-        overrides={"fileBase": "sweden_waste_ratio"},
     ),
     _page(
         "sweden",
@@ -562,7 +548,6 @@ MAP_PAGES = [
         "Aggregated collected amount of organic fractions (kg/cap/a)",
         "map/sweden/organic-collection-amount/",
         "waste-atlas-sweden-organic-collection-amount-map",
-        overrides={"fileBase": "sweden_organic_collection_amount"},
     ),
     _page(
         "sweden",
@@ -570,7 +555,6 @@ MAP_PAGES = [
         "Organic stream separation rate (%)",
         "map/sweden/organic-waste-ratio/",
         "waste-atlas-sweden-organic-waste-ratio-map",
-        overrides={"fileBase": "sweden_organic_waste_ratio"},
     ),
     # ── denmark ──
     _page(
@@ -580,7 +564,6 @@ MAP_PAGES = [
         "map/denmark/administrative-level/",
         "waste-atlas-orga-level-denmark-map",
         config_key="orga_level_eu",
-        overrides={"fileBase": "map31_orga_level_denmark"},
         lock=False,
     ),
     _page(
@@ -590,7 +573,6 @@ MAP_PAGES = [
         "map/denmark/administrative-level/collections/",
         "waste-atlas-collection-orga-level-denmark-map",
         config_key="collection_orga_level_eu",
-        overrides={"fileBase": "map31_collection_orga_level_denmark"},
         lock=False,
     ),
     _page(
@@ -633,7 +615,6 @@ MAP_PAGES = [
         "map/netherlands/administrative-level/",
         "waste-atlas-orga-level-netherlands-map",
         config_key="orga_level_eu",
-        overrides={"fileBase": "map32_orga_level_netherlands"},
     ),
     _page(
         "netherlands",
@@ -642,7 +623,6 @@ MAP_PAGES = [
         "map/netherlands/administrative-level/collections/",
         "waste-atlas-collection-orga-level-netherlands-map",
         config_key="collection_orga_level_eu",
-        overrides={"fileBase": "map32_collection_orga_level_netherlands"},
     ),
     _page(
         "netherlands",
@@ -687,7 +667,6 @@ MAP_PAGES = [
         "map/belgium/administrative-level/",
         "waste-atlas-orga-level-belgium-map",
         config_key="orga_level_eu",
-        overrides={"fileBase": "map33_orga_level_belgium"},
     ),
     _page(
         "belgium",
@@ -696,7 +675,6 @@ MAP_PAGES = [
         "map/belgium/administrative-level/collections/",
         "waste-atlas-collection-orga-level-belgium-map",
         config_key="collection_orga_level_eu",
-        overrides={"fileBase": "map33_collection_orga_level_belgium"},
     ),
     # ── belgium_flanders ──
     _page(
@@ -706,7 +684,6 @@ MAP_PAGES = [
         "map/belgium-flanders/administrative-level/",
         "waste-atlas-orga-level-belgium-flanders-map",
         config_key="orga_level_eu",
-        overrides={"fileBase": "map35_orga_level_belgium_flanders"},
     ),
     _page(
         "belgium_flanders",
@@ -715,7 +692,6 @@ MAP_PAGES = [
         "map/belgium-flanders/administrative-level/collections/",
         "waste-atlas-collection-orga-level-belgium-flanders-map",
         config_key="collection_orga_level_eu",
-        overrides={"fileBase": "map35_collection_orga_level_belgium_flanders"},
     ),
     # ── generic ──
     _page(

--- a/sources/waste_collection/waste_atlas/templates/waste_atlas/karte0_europe_data_coverage.html
+++ b/sources/waste_collection/waste_atlas/templates/waste_atlas/karte0_europe_data_coverage.html
@@ -1,5 +1,5 @@
 {% extends base_template %}
-{% load static %}
+{% load static atlas_tags %}
 {% block title %}
   Waste Atlas — {{ map_title }}
 {% endblock title %}
@@ -431,12 +431,12 @@
       });
       if (btnSVG) {
         btnSVG.addEventListener('click', function () {
-          WasteAtlasChoropleth.exportElementSVG(svgEl, 'waste_atlas_europe_data_coverage.svg');
+          WasteAtlasChoropleth.exportElementSVG(svgEl, '{% atlas_export_file_base "" "europe_data_coverage" %}.svg');
         });
       }
       if (btnPNG) {
         btnPNG.addEventListener('click', function () {
-          WasteAtlasChoropleth.exportElementPNG(svgEl, 'waste_atlas_europe_data_coverage.png');
+          WasteAtlasChoropleth.exportElementPNG(svgEl, '{% atlas_export_file_base "" "europe_data_coverage" %}.png');
         });
       }
     });

--- a/sources/waste_collection/waste_atlas/templates/waste_atlas/karte41_europe_biowaste_collection_amount.html
+++ b/sources/waste_collection/waste_atlas/templates/waste_atlas/karte41_europe_biowaste_collection_amount.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static %}
+{% load static atlas_tags %}
 {% block title %}
   Waste Atlas — {{ map_title }}
 {% endblock title %}
@@ -661,12 +661,12 @@
       });
       if (btnSVG) {
         btnSVG.addEventListener('click', function () {
-          WasteAtlasChoropleth.exportElementSVG(svgEl, 'waste_atlas_europe_biowaste_collection_amount.svg');
+          WasteAtlasChoropleth.exportElementSVG(svgEl, '{% atlas_export_file_base "" "europe_biowaste_collection_amount" %}.svg');
         });
       }
       if (btnPNG) {
         btnPNG.addEventListener('click', function () {
-          WasteAtlasChoropleth.exportElementPNG(svgEl, 'waste_atlas_europe_biowaste_collection_amount.png');
+          WasteAtlasChoropleth.exportElementPNG(svgEl, '{% atlas_export_file_base "" "europe_biowaste_collection_amount" %}.png');
         });
       }
     });

--- a/sources/waste_collection/waste_atlas/templatetags/atlas_tags.py
+++ b/sources/waste_collection/waste_atlas/templatetags/atlas_tags.py
@@ -17,6 +17,34 @@ DATABASE_EDITABLE_OVERRIDE_KEYS = frozenset(
     }
 )
 
+EXPORT_FILE_NAME_PREFIX = "waste_atlas"
+
+
+def export_file_base(map_set, theme):
+    """Derive the deterministic export file-name stem for a map page.
+
+    Every Waste Atlas map export (SVG/PNG, plus the ``_change_<from>_<to>``
+    suffix the renderer appends for change maps) is named from the page's
+    structural identity: its map set (``selector_set``) and theme.  This keeps
+    naming homogeneous across all maps without per-page or per-configuration
+    ``fileBase`` values.
+
+    Region-locked maps use ``waste_atlas_<set>_<theme>`` with the set
+    lowercased and hyphens turned into underscores (``DE-NW`` → ``de_nw``);
+    generic maps (no map set) use ``waste_atlas_<theme>``.
+    """
+    set_slug = (map_set or "").strip().lower().replace("-", "_")
+    theme_slug = (theme or "").strip()
+    if set_slug:
+        return f"{EXPORT_FILE_NAME_PREFIX}_{set_slug}_{theme_slug}"
+    return f"{EXPORT_FILE_NAME_PREFIX}_{theme_slug}"
+
+
+@register.simple_tag
+def atlas_export_file_base(map_set, theme):
+    """Template-friendly wrapper around :func:`export_file_base`."""
+    return export_file_base(map_set, theme)
+
 
 @register.simple_tag(takes_context=True)
 def atlas_js_config(context, config_key):
@@ -27,9 +55,16 @@ def atlas_js_config(context, config_key):
     nutsLevel), and hard-coded DOM ids.  The result is intended to be passed
     through Django's ``json_script`` filter in the template for safe JSON
     injection.
+
+    The export ``fileBase`` is always derived from the page's map set and
+    theme (see :func:`export_file_base`); any stored or overridden
+    ``fileBase`` is ignored so file naming stays homogeneous across maps.
     """
     config = dict(MAP_CONFIGS.get(config_key, {}))
+    config.pop("fileBase", None)
     for key, value in (context.get("map_config_overrides") or {}).items():
+        if key == "fileBase":
+            continue
         if key not in DATABASE_EDITABLE_OVERRIDE_KEYS or key not in config:
             config[key] = value
 
@@ -37,6 +72,15 @@ def atlas_js_config(context, config_key):
     config.setdefault("svgId", "atlas-svg")
     config.setdefault("containerId", "map-container")
     config.setdefault("loadingId", "loading-overlay")
+
+    # Deterministic export file name — one rule for every map page.
+    # Use the page's structural selector_set (None for generic maps), not the
+    # runtime-resolved atlas_map_set which may default to a country for
+    # generic pages.
+    config["fileBase"] = export_file_base(
+        context.get("atlas_page_selector_set"),
+        context.get("atlas_active_theme"),
+    )
 
     # Runtime context from the view
     config["country"] = context.get("country", "DE")

--- a/sources/waste_collection/waste_atlas/views.py
+++ b/sources/waste_collection/waste_atlas/views.py
@@ -243,6 +243,7 @@ class AtlasMapView(WasteAtlasGroupMixin, TemplateView):
         region_label = MAP_SET_LABELS.get(selected_map_set, "")
         overview_href = reverse("waste-atlas-overview")
         ctx["atlas_map_set"] = selected_map_set
+        ctx["atlas_page_selector_set"] = page.get("selector_set")
         ctx["breadcrumb_module_label"] = "Waste Atlas"
         ctx["breadcrumb_module_url"] = overview_href
         if region_label:


### PR DESCRIPTION
## Summary

- Export file names for waste-atlas maps were manually defined per map in three places (stored DB configs, per-page overrides in `pages.py`, and hardcoded strings in the two Europe templates), with inconsistent conventions (`map29_...`, `sweden_...`, `biowaste_collection_amount`, …).
- Replaced all of them with a single deterministic rule in `atlas_tags.export_file_base`: `waste_atlas_<set>_<theme>` for region-locked maps (set lowercased, hyphens to underscores) and `waste_atlas_<theme>` for generic maps.
- The choropleth renderer's existing `_change_<from>_<to>` suffix for change maps is preserved.

### Changes

- Add `export_file_base()` + `atlas_export_file_base` template tag
- Derive `fileBase` in `atlas_js_config` from the page's `selector_set` + theme, ignoring any stored or overridden `fileBase`
- Remove all 24 `fileBase` overrides from `pages.py`
- Add migration `0004` to strip `fileBase` from stored map configurations
- Drop `fileBase` from `REQUIRED_CONFIG_KEYS`
- Route the two Europe templates through the same template tag

### Naming examples

| Map | Before | After |
|-----|--------|-------|
| Germany / collection_system | `collection_systems` | `waste_atlas_de_collection_system` |
| Italy / orga_level | `map29_orga_level_italy` | `waste_atlas_it_orga_level` |
| NRW / participation_policy | `participation_policy` | `waste_atlas_de_nw_participation_policy` |
| Sweden / biowaste_collection_amount | `sweden_biowaste_collection_amount` | `waste_atlas_se_biowaste_collection_amount` |
| South Tyrol / target_waste_category | `south_tyrol_target_waste_category` | `waste_atlas_it_st_target_waste_category` |
| Generic / orga_level | `collector_administrative_level` | `waste_atlas_orga_level` |
| Europe data coverage | `waste_atlas_europe_data_coverage` | `waste_atlas_europe_data_coverage` (unchanged) |

#### Test plan

- [x] `WasteAtlasExportFileNameTestCase` — 3 new tests asserting deterministic derivation, no page-level overrides, no stored `fileBase`
- [x] `test_waste_atlas_configuration_views` (27 tests) — all pass
- [x] `test_waste_atlas_map_configs` (24 tests) — all pass
- [x] `test_waste_atlas_map_page_layout`, `test_waste_atlas_responsive_map`, `test_waste_atlas_open_in_new_tab`, `test_waste_atlas_composite_collection_picker`, `test_waste_atlas_biowaste_amount`, `test_waste_atlas_configuration_model` (79 tests) — all pass
- [x] `brit.tests.test_templates`, `sources.tests.test_views` (85 tests) — all pass
- [x] `ruff check` + `ruff format --check` — clean
- [x] `makemigrations --check` — no missing migrations

Generated with [Devin](https://devin.ai)