### PR TITLE
feat: add Rheinland-Pfalz residual waste maps

### DIFF
--- a/sources/waste_collection/tests/test_waste_atlas_residual_waste_composition.py
+++ b/sources/waste_collection/tests/test_waste_atlas_residual_waste_composition.py
@@ -1,0 +1,282 @@
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from maps.models import Region
+from sources.waste_collection.models import (
+    Collection,
+    CollectionCatchment,
+    CollectionPropertyValue,
+    CollectionSystem,
+    WasteCategory,
+)
+from sources.waste_collection.waste_atlas.map_configs import MAP_CONFIGS
+from sources.waste_collection.waste_atlas.map_selection import (
+    COLLECTION_DETAIL_CATEGORY_BY_THEME,
+    MAP_SELECTION_WASTE_CATEGORY_OVERRIDES,
+    THEME_LABELS,
+    WASTE_ATLAS_MAP_SELECTIONS,
+)
+from sources.waste_collection.waste_atlas.pages import MAP_PAGES
+from utils.properties.models import Property, Unit
+
+
+class ResidualWasteCompositionViewSetTests(APITestCase):
+    endpoint = "/waste_collection/api/waste-atlas/residual-waste-composition/"
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.biowaste_property = Property.objects.create(
+            name="total biowaste in residual waste"
+        )
+        cls.food_waste_property = Property.objects.create(
+            name="total food waste in residual waste"
+        )
+        cls.percentage_unit, _ = Unit.objects.get_or_create(name="%")
+        cls.kg_unit, _ = Unit.objects.get_or_create(name="kg/(cap.*a)")
+        cls.biowaste_property.allowed_units.add(
+            cls.percentage_unit,
+            cls.kg_unit,
+        )
+        cls.food_waste_property.allowed_units.add(cls.kg_unit)
+
+        cls.residual_category, _ = WasteCategory.objects.get_or_create(
+            name="Residual waste"
+        )
+        cls.biowaste_category, _ = WasteCategory.objects.get_or_create(name="Biowaste")
+        cls.door_to_door, _ = CollectionSystem.objects.get_or_create(
+            name="Door to door"
+        )
+
+        cls.region = Region.objects.create(
+            name="Rheinland-Pfalz composition test region",
+            country="DE",
+        )
+        cls.catchment_with_data = CollectionCatchment.objects.create(
+            name="Composition with data",
+            region=cls.region,
+        )
+        cls.previous_collection = cls._create_collection(
+            cls.catchment_with_data,
+            cls.residual_category,
+            2023,
+        )
+        cls.current_collection = cls._create_collection(
+            cls.catchment_with_data,
+            cls.residual_category,
+            2024,
+        )
+        cls.current_collection.predecessors.add(cls.previous_collection)
+
+        cls._create_property_value(
+            cls.previous_collection,
+            cls.biowaste_property,
+            cls.percentage_unit,
+            2021,
+            18.24,
+        )
+        cls._create_property_value(
+            cls.previous_collection,
+            cls.biowaste_property,
+            cls.percentage_unit,
+            2023,
+            23.44,
+        )
+        cls._create_property_value(
+            cls.current_collection,
+            cls.biowaste_property,
+            cls.kg_unit,
+            2024,
+            30.2446,
+        )
+        cls._create_property_value(
+            cls.current_collection,
+            cls.food_waste_property,
+            cls.kg_unit,
+            2024,
+            26.1086,
+        )
+        cls._create_property_value(
+            cls.current_collection,
+            cls.biowaste_property,
+            cls.percentage_unit,
+            2025,
+            88,
+            publication_status="review",
+        )
+        cls.staff_user = get_user_model().objects.create_user(
+            username="composition-map-staff",
+            is_staff=True,
+        )
+
+        cls.catchment_without_data = CollectionCatchment.objects.create(
+            name="Composition without data",
+            region=cls.region,
+        )
+        cls._create_collection(
+            cls.catchment_without_data,
+            cls.residual_category,
+            2024,
+        )
+
+        cls.biowaste_only_catchment = CollectionCatchment.objects.create(
+            name="Biowaste-only composition data",
+            region=cls.region,
+        )
+        biowaste_collection = cls._create_collection(
+            cls.biowaste_only_catchment,
+            cls.biowaste_category,
+            2024,
+        )
+        cls._create_property_value(
+            biowaste_collection,
+            cls.biowaste_property,
+            cls.percentage_unit,
+            2024,
+            99,
+        )
+
+    @classmethod
+    def _create_collection(cls, catchment, waste_category, year):
+        return Collection.objects.create(
+            catchment=catchment,
+            waste_category=waste_category,
+            collection_system=cls.door_to_door,
+            valid_from=date(year, 1, 1),
+            publication_status="published",
+        )
+
+    @staticmethod
+    def _create_property_value(
+        collection,
+        property_obj,
+        unit,
+        year,
+        average,
+        publication_status="published",
+    ):
+        return CollectionPropertyValue.objects.create(
+            collection=collection,
+            property=property_obj,
+            unit=unit,
+            year=year,
+            average=average,
+            publication_status=publication_status,
+        )
+
+    def _by_catchment(self):
+        response = self.client.get(
+            self.endpoint,
+            {"country": "DE", "year": 2024},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return {row["catchment_id"]: row for row in response.data}
+
+    def test_returns_requested_metrics_with_analysis_and_amount_basis_years(self):
+        row = self._by_catchment()[self.catchment_with_data.id]
+
+        self.assertEqual(
+            row,
+            {
+                "catchment_id": self.catchment_with_data.id,
+                "bw_rw_percentage": 23.4,
+                "bw_rw_kg": 30.2,
+                "fwtot_rw_kg": 26.1,
+                "analysis_year": 2023,
+                "amount_basis_year": 2024,
+            },
+        )
+
+    def test_returns_null_metrics_for_residual_catchment_without_analysis(self):
+        row = self._by_catchment()[self.catchment_without_data.id]
+
+        self.assertEqual(
+            row,
+            {
+                "catchment_id": self.catchment_without_data.id,
+                "bw_rw_percentage": None,
+                "bw_rw_kg": None,
+                "fwtot_rw_kg": None,
+                "analysis_year": None,
+                "amount_basis_year": 2024,
+            },
+        )
+
+    def test_excludes_catchments_without_a_residual_waste_collection(self):
+        self.assertNotIn(self.biowaste_only_catchment.id, self._by_catchment())
+
+    def test_staff_preview_includes_the_latest_review_value(self):
+        self.client.force_authenticate(self.staff_user)
+
+        row = self._by_catchment()[self.catchment_with_data.id]
+
+        self.assertEqual(row["bw_rw_percentage"], 88)
+        self.assertEqual(row["analysis_year"], 2025)
+
+
+class RheinlandPfalzResidualWasteCompositionMapTests(TestCase):
+    expected_maps = {
+        "bw_rw_percentage": {
+            "title": "Total biowaste in residual waste",
+            "legend_title": "Share of residual waste (%)",
+            "file_base": "rp_bw_rw_percentage",
+        },
+        "bw_rw_kg": {
+            "title": "Total biowaste in residual waste",
+            "legend_title": "Amount (kg/cap/a)",
+            "file_base": "rp_bw_rw_kg",
+        },
+        "fwtot_rw_kg": {
+            "title": "Total food waste in residual waste",
+            "legend_title": "Amount (kg/cap/a)",
+            "file_base": "rp_fwtot_rw_kg",
+        },
+    }
+
+    def test_rheinland_pfalz_registers_the_three_composition_maps(self):
+        pages_by_theme = {
+            page["theme"]: page for page in MAP_PAGES if page["region"] == "rp"
+        }
+
+        for theme, expected in self.expected_maps.items():
+            with self.subTest(theme=theme):
+                page = pages_by_theme[theme]
+                self.assertEqual(page["title"], expected["title"])
+                self.assertEqual(page["config_key"], theme)
+                self.assertIn(theme, WASTE_ATLAS_MAP_SELECTIONS["DE-RP"]["themes"])
+                self.assertEqual(
+                    MAP_SELECTION_WASTE_CATEGORY_OVERRIDES[theme],
+                    "residual",
+                )
+                self.assertEqual(
+                    COLLECTION_DETAIL_CATEGORY_BY_THEME[theme],
+                    "residual",
+                )
+                self.assertIn(theme, THEME_LABELS)
+
+    def test_composition_maps_use_quartiles_and_the_shared_endpoint(self):
+        for theme, expected in self.expected_maps.items():
+            with self.subTest(theme=theme):
+                config = MAP_CONFIGS[theme]
+                self.assertEqual(
+                    config["dataUrl"],
+                    "/waste_collection/api/waste-atlas/residual-waste-composition/",
+                )
+                self.assertEqual(config["dataField"], "_classified")
+                self.assertEqual(config["numericField"], theme)
+                self.assertEqual(len(config["quartileColors"]), 4)
+                self.assertTrue(config["enableQuartiles"])
+                self.assertEqual(config["legendTitle"], expected["legend_title"])
+                self.assertEqual(config["fileBase"], expected["file_base"])
+
+    def test_amount_maps_explain_the_2024_statistics_basis(self):
+        for theme in ("bw_rw_kg", "fwtot_rw_kg"):
+            with self.subTest(theme=theme):
+                config = MAP_CONFIGS[theme]
+                self.assertIn(
+                    {"field": "amount_basis_year", "label": "Amount basis year"},
+                    config["tooltipFields"],
+                )

--- a/sources/waste_collection/waste_atlas/map_selection.py
+++ b/sources/waste_collection/waste_atlas/map_selection.py
@@ -23,6 +23,8 @@ THEME_LABELS = {
     "biowaste_impurity": "Biowaste impurity",
     "biowaste_min_bin_size": "Biowaste bin size",
     "biowaste_required_bin_capacity": "Biowaste bin capacity",
+    "bw_rw_kg": "Biowaste in residual waste (kg)",
+    "bw_rw_percentage": "Biowaste in residual waste (%)",
     "collection_count_ratio": "Collection-count ratio",
     "collection_orga_level": "Collections: admin. level",
     "collection_point_count": "Collection points",
@@ -36,6 +38,7 @@ THEME_LABELS = {
     "connection_rate": "Connection rate",
     "participation_policy": "Participation Policy",
     "food_waste_category": "Accepted food waste",
+    "fwtot_rw_kg": "Food waste in residual waste (kg)",
     "green_waste_collection_amount": "Green waste amount",
     "green_waste_collection_system_count": "Green waste system count",
     "min_bin_size_ratio": "Minimum bin-size ratio",
@@ -191,6 +194,9 @@ DIRECTORY_THEME_GROUP_SECTIONS = {
     "collection_count_ratio": "counts",
     "fee_system": "fees",
     "collection_amount": "amounts",
+    "bw_rw_percentage": "amounts",
+    "bw_rw_kg": "amounts",
+    "fwtot_rw_kg": "amounts",
     "waste_ratio": "amounts",
 }
 
@@ -231,6 +237,9 @@ MAP_SELECTION_THEME_ORDER = {
     "organic_collection_amount": 630,
     "waste_ratio": 640,
     "organic_waste_ratio": 650,
+    "bw_rw_percentage": 660,
+    "bw_rw_kg": 661,
+    "fwtot_rw_kg": 662,
     "connection_rate": 700,
     "participation_policy": 710,
 }
@@ -278,6 +287,9 @@ MAP_SELECTION_WASTE_CATEGORY_OVERRIDES = {
     "paper_bags": "biowaste",
     "plastic_bags": "biowaste",
     "collection_support": "biowaste",
+    "bw_rw_percentage": "residual",
+    "bw_rw_kg": "residual",
+    "fwtot_rw_kg": "residual",
 }
 
 # Themes whose displayed value is derived from one deterministic primary
@@ -286,6 +298,8 @@ MAP_SELECTION_WASTE_CATEGORY_OVERRIDES = {
 COLLECTION_DETAIL_CATEGORY_BY_THEME = {
     "access_control": "biowaste",
     "bin_configuration": "biowaste",
+    "bw_rw_percentage": "residual",
+    "bw_rw_kg": "residual",
     "biowaste_collection_point_count": "biowaste",
     "biowaste_collection_system": "biowaste",
     "biowaste_fee_system": "biowaste",
@@ -295,6 +309,7 @@ COLLECTION_DETAIL_CATEGORY_BY_THEME = {
     "collection_support": "biowaste",
     "collection_system": "biowaste",
     "food_waste_category": "biowaste",
+    "fwtot_rw_kg": "residual",
     "paper_bags": "biowaste",
     "participation_policy": "biowaste",
     "plastic_bags": "biowaste",

--- a/sources/waste_collection/waste_atlas/migrations/0004_seed_residual_waste_composition_maps.py
+++ b/sources/waste_collection/waste_atlas/migrations/0004_seed_residual_waste_composition_maps.py
@@ -1,0 +1,91 @@
+from django.db import migrations
+
+NO_DATA_COLOR = "#e0e0e0"
+QUARTILE_COLORS = ["#fee5d9", "#fcae91", "#fb6a4a", "#cb181d"]
+QUARTILE_CATEGORIES = [
+    {"value": "q1", "label": "Quartile 1", "color": QUARTILE_COLORS[0]},
+    {"value": "q2", "label": "Quartile 2", "color": QUARTILE_COLORS[1]},
+    {"value": "q3", "label": "Quartile 3", "color": QUARTILE_COLORS[2]},
+    {"value": "q4", "label": "Quartile 4", "color": QUARTILE_COLORS[3]},
+]
+DATA_URL = "/waste_collection/api/waste-atlas/residual-waste-composition/"
+ANALYSIS_YEAR_TOOLTIP = {"field": "analysis_year", "label": "Analysis year"}
+AMOUNT_BASIS_YEAR_TOOLTIP = {
+    "field": "amount_basis_year",
+    "label": "Amount basis year",
+}
+
+
+def _config(*, title, numeric_field, legend_title, file_base, tooltip_fields):
+    return {
+        "title": title,
+        "dataUrl": DATA_URL,
+        "dataField": "_classified",
+        "categories": QUARTILE_CATEGORIES,
+        "noDataColor": NO_DATA_COLOR,
+        "noDataLabel": "No data",
+        "legendTitle": legend_title,
+        "fileBase": file_base,
+        "numericField": numeric_field,
+        "quartileColors": QUARTILE_COLORS,
+        "enableQuartiles": True,
+        "tooltipFields": tooltip_fields,
+    }
+
+
+MAP_CONFIGS = {
+    "bw_rw_percentage": _config(
+        title="Total biowaste in residual waste",
+        numeric_field="bw_rw_percentage",
+        legend_title="Share of residual waste (%)",
+        file_base="rp_bw_rw_percentage",
+        tooltip_fields=[ANALYSIS_YEAR_TOOLTIP],
+    ),
+    "bw_rw_kg": _config(
+        title="Total biowaste in residual waste",
+        numeric_field="bw_rw_kg",
+        legend_title="Amount (kg/cap/a)",
+        file_base="rp_bw_rw_kg",
+        tooltip_fields=[ANALYSIS_YEAR_TOOLTIP, AMOUNT_BASIS_YEAR_TOOLTIP],
+    ),
+    "fwtot_rw_kg": _config(
+        title="Total food waste in residual waste",
+        numeric_field="fwtot_rw_kg",
+        legend_title="Amount (kg/cap/a)",
+        file_base="rp_fwtot_rw_kg",
+        tooltip_fields=[ANALYSIS_YEAR_TOOLTIP, AMOUNT_BASIS_YEAR_TOOLTIP],
+    ),
+}
+
+
+def seed_map_configurations(apps, schema_editor):
+    configuration_model = apps.get_model(
+        "waste_atlas",
+        "WasteAtlasMapConfiguration",
+    )
+    for key, configuration in MAP_CONFIGS.items():
+        configuration_model.objects.update_or_create(
+            key=key,
+            defaults={"configuration": configuration},
+        )
+
+
+def remove_map_configurations(apps, schema_editor):
+    configuration_model = apps.get_model(
+        "waste_atlas",
+        "WasteAtlasMapConfiguration",
+    )
+    configuration_model.objects.filter(key__in=MAP_CONFIGS).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("waste_atlas", "0003_seed_target_waste_category"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            seed_map_configurations,
+            remove_map_configurations,
+        )
+    ]

--- a/sources/waste_collection/waste_atlas/pages.py
+++ b/sources/waste_collection/waste_atlas/pages.py
@@ -2259,6 +2259,27 @@ MAP_PAGES = [
     ),
     _page(
         "rp",
+        "bw_rw_percentage",
+        "Total biowaste in residual waste",
+        "map/rp/biowaste-in-residual-waste-percentage/",
+        "waste-atlas-rp-bw-rw-percentage-map",
+    ),
+    _page(
+        "rp",
+        "bw_rw_kg",
+        "Total biowaste in residual waste",
+        "map/rp/biowaste-in-residual-waste-amount/",
+        "waste-atlas-rp-bw-rw-kg-map",
+    ),
+    _page(
+        "rp",
+        "fwtot_rw_kg",
+        "Total food waste in residual waste",
+        "map/rp/food-waste-in-residual-waste-amount/",
+        "waste-atlas-rp-fwtot-rw-kg-map",
+    ),
+    _page(
+        "rp",
         "biowaste_collection_amount",
         "Specifically collected amount of biowaste",
         "map/rp/biowaste-collection-amount/",

--- a/sources/waste_collection/waste_atlas/router.py
+++ b/sources/waste_collection/waste_atlas/router.py
@@ -47,6 +47,7 @@ from .viewsets import (
     ResidualFrequencyTypeViewSet,
     ResidualMinBinSizeViewSet,
     ResidualRequiredBinCapacityViewSet,
+    ResidualWasteCompositionViewSet,
     TargetWasteCategoryViewSet,
     WasteRatioViewSet,
     WeeklyBpAccessDaysViewSet,
@@ -293,6 +294,11 @@ router.register(
     "biowaste-impurity",
     BiowasteImpurityViewSet,
     basename="api-waste-atlas-biowaste-impurity",
+)
+router.register(
+    "residual-waste-composition",
+    ResidualWasteCompositionViewSet,
+    basename="api-waste-atlas-residual-waste-composition",
 )
 router.register(
     "weekly-bp-access-days",

--- a/sources/waste_collection/waste_atlas/serializers.py
+++ b/sources/waste_collection/waste_atlas/serializers.py
@@ -337,6 +337,23 @@ class CatchmentBiowasteImpuritySerializer(serializers.Serializer):
         return data
 
 
+class CatchmentResidualWasteCompositionSerializer(serializers.Serializer):
+    """Flat composition-analysis values for residual-waste catchments."""
+
+    catchment_id = serializers.IntegerField()
+    bw_rw_percentage = serializers.FloatField(allow_null=True)
+    bw_rw_kg = serializers.FloatField(allow_null=True)
+    fwtot_rw_kg = serializers.FloatField(allow_null=True)
+    analysis_year = serializers.IntegerField(allow_null=True)
+    amount_basis_year = serializers.IntegerField()
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        for field in ("bw_rw_percentage", "bw_rw_kg", "fwtot_rw_kg"):
+            data[field] = _round_one_decimal(data.get(field))
+        return data
+
+
 class CatchmentWeeklyBpAccessDaysSerializer(serializers.Serializer):
     """Flat JSON serializer for weekly bring-point access days per catchment."""
 

--- a/sources/waste_collection/waste_atlas/viewsets.py
+++ b/sources/waste_collection/waste_atlas/viewsets.py
@@ -69,6 +69,7 @@ from .serializers import (
     CatchmentParticipationPolicySerializer,
     CatchmentPopulationSerializer,
     CatchmentRequiredBinCapacitySerializer,
+    CatchmentResidualWasteCompositionSerializer,
     CatchmentTargetWasteCategorySerializer,
     CatchmentWasteRatioSerializer,
     CatchmentWeeklyBpAccessDaysSerializer,
@@ -144,6 +145,10 @@ CONNECTION_RATE_PROPERTY_ID = 4
 COLLECTION_POINT_COUNT_PROPERTY_NAME = "number of collection points"
 BIOWASTE_IMPURITY_RATE_PROPERTY_NAME = "biowaste impurity rate"
 WEEKLY_BP_ACCESS_DAYS_PROPERTY_NAME = "weekly bring-point access days"
+BIOWASTE_IN_RESIDUAL_WASTE_PROPERTY_NAME = "total biowaste in residual waste"
+FOOD_WASTE_IN_RESIDUAL_WASTE_PROPERTY_NAME = "total food waste in residual waste"
+PERCENTAGE_UNIT_NAME = "%"
+SPECIFIC_AMOUNT_UNIT_NAME = "kg/(cap.*a)"
 
 # Priority for picking the primary collection system per catchment.
 # Lower number = higher priority.
@@ -457,6 +462,58 @@ def _latest_connection_rate_values(collection_ids):
         if latest is not None:
             latest_by_selected_id[selected_id] = latest
 
+    return latest_by_selected_id
+
+
+def _latest_property_values(
+    collection_ids,
+    *,
+    property_name,
+    unit_name,
+    year=None,
+    user=None,
+):
+    """Return the latest matching value from each selected collection's chain."""
+    version_chains = _collection_version_chains(collection_ids)
+    if not version_chains:
+        return {}
+
+    all_chain_ids = set().union(*version_chains.values())
+    filters = {
+        "collection_id__in": all_chain_ids,
+        "property__name": property_name,
+        "unit__name": unit_name,
+        "average__isnull": False,
+        "publication_status__in": _visible_statuses(user),
+    }
+    if year is not None:
+        filters["year"] = year
+
+    values_by_collection_id = {}
+    for row in CollectionPropertyValue.objects.filter(**filters).values(
+        "id",
+        "collection_id",
+        "average",
+        "year",
+    ):
+        values_by_collection_id.setdefault(row["collection_id"], []).append(row)
+
+    latest_by_selected_id = {}
+    for selected_id, chain_ids in version_chains.items():
+        candidates = [
+            candidate
+            for chain_id in chain_ids
+            for candidate in values_by_collection_id.get(chain_id, ())
+        ]
+        if candidates:
+            latest_by_selected_id[selected_id] = max(
+                candidates,
+                key=lambda candidate: (
+                    candidate["year"] is not None,
+                    candidate["year"] or 0,
+                    candidate["id"],
+                ),
+            )
     return latest_by_selected_id
 
 
@@ -3152,6 +3209,82 @@ class BiowasteImpurityViewSet(WasteAtlasViewSet):
             )
 
         serializer = CatchmentBiowasteImpuritySerializer(data, many=True)
+        return Response(serializer.data)
+
+
+class ResidualWasteCompositionViewSet(WasteAtlasViewSet):
+    """Return residual-waste composition analyses for atlas maps.
+
+    The selected collection is scoped by the requested atlas year. Percentage
+    values retain the analysis year stored on the property value, while the
+    amount fields use statistics from the requested year.
+    """
+
+    permission_classes = [permissions.AllowAny]
+
+    def list(self, request):
+        country, year = _parse_country_year(request)
+        nuts_prefixes = _parse_nuts_prefixes(request)
+        best = _select_primary_collections(
+            country,
+            year,
+            ["Residual waste"],
+            nuts_prefixes,
+            user=request.user,
+        )
+        collection_ids = [row["collection_id"] for row in best.values()]
+
+        percentage_values = _latest_property_values(
+            collection_ids,
+            property_name=BIOWASTE_IN_RESIDUAL_WASTE_PROPERTY_NAME,
+            unit_name=PERCENTAGE_UNIT_NAME,
+            user=request.user,
+        )
+        biowaste_amounts = _latest_property_values(
+            collection_ids,
+            property_name=BIOWASTE_IN_RESIDUAL_WASTE_PROPERTY_NAME,
+            unit_name=SPECIFIC_AMOUNT_UNIT_NAME,
+            year=year,
+            user=request.user,
+        )
+        food_waste_amounts = _latest_property_values(
+            collection_ids,
+            property_name=FOOD_WASTE_IN_RESIDUAL_WASTE_PROPERTY_NAME,
+            unit_name=SPECIFIC_AMOUNT_UNIT_NAME,
+            year=year,
+            user=request.user,
+        )
+
+        data = []
+        for catchment_id, collection_row in best.items():
+            collection_id = collection_row["collection_id"]
+            percentage = percentage_values.get(collection_id)
+            biowaste_amount = biowaste_amounts.get(collection_id)
+            food_waste_amount = food_waste_amounts.get(collection_id)
+            data.append(
+                {
+                    "catchment_id": catchment_id,
+                    "bw_rw_percentage": (
+                        percentage["average"] if percentage is not None else None
+                    ),
+                    "bw_rw_kg": (
+                        biowaste_amount["average"]
+                        if biowaste_amount is not None
+                        else None
+                    ),
+                    "fwtot_rw_kg": (
+                        food_waste_amount["average"]
+                        if food_waste_amount is not None
+                        else None
+                    ),
+                    "analysis_year": (
+                        percentage["year"] if percentage is not None else None
+                    ),
+                    "amount_basis_year": year,
+                }
+            )
+
+        serializer = CatchmentResidualWasteCompositionSerializer(data, many=True)
         return Response(serializer.data)
 
 


### PR DESCRIPTION
## What changed

- adds a residual-waste composition Waste Atlas endpoint
- adds three Rheinland-Pfalz quartile maps for total biowaste percentage, total biowaste amount, and total food-waste amount
- preserves the source analysis year while exposing 2024 as the basis year for amount values
- limits non-public collection property values to staff users
- seeds the three reusable map configurations

## Why

The 2024 Rheinland-Pfalz workbook contains residual-waste composition analysis data requested for initial Waste Atlas review.

## Impact

The maps appear in the Rheinland-Pfalz residual-waste selector. Missing measurements remain visible as no-data catchments. Review-status values can be inspected by staff and become public only after approval.

## Validation

- 7 focused residual-waste composition tests
- 63 related Waste Atlas regression tests
- Ruff check and format check
- Django system check
- `makemigrations --check --dry-run`
- local integration against an isolated production snapshot: 32 catchments, with 27/27/25 populated metric counts

The one-off data import is maintained separately in `lueho/BRIT-data`.