### PR TITLE
fix: merge Waste Atlas migration branches

### DIFF
--- a/sources/waste_collection/tests/test_waste_atlas_residual_waste_composition.py
+++ b/sources/waste_collection/tests/test_waste_atlas_residual_waste_composition.py
@@ -222,17 +222,14 @@ class RheinlandPfalzResidualWasteCompositionMapTests(TestCase):
         "bw_rw_percentage": {
             "title": "Total biowaste in residual waste",
             "legend_title": "Share of residual waste (%)",
-            "file_base": "rp_bw_rw_percentage",
         },
         "bw_rw_kg": {
             "title": "Total biowaste in residual waste",
             "legend_title": "Amount (kg/cap/a)",
-            "file_base": "rp_bw_rw_kg",
         },
         "fwtot_rw_kg": {
             "title": "Total food waste in residual waste",
             "legend_title": "Amount (kg/cap/a)",
-            "file_base": "rp_fwtot_rw_kg",
         },
     }
 
@@ -270,7 +267,7 @@ class RheinlandPfalzResidualWasteCompositionMapTests(TestCase):
                 self.assertEqual(len(config["quartileColors"]), 4)
                 self.assertTrue(config["enableQuartiles"])
                 self.assertEqual(config["legendTitle"], expected["legend_title"])
-                self.assertEqual(config["fileBase"], expected["file_base"])
+                self.assertNotIn("fileBase", config)
 
     def test_amount_maps_explain_the_2024_statistics_basis(self):
         for theme in ("bw_rw_kg", "fwtot_rw_kg"):

--- a/sources/waste_collection/waste_atlas/migrations/0005_merge_20260730_1555.py
+++ b/sources/waste_collection/waste_atlas/migrations/0005_merge_20260730_1555.py
@@ -1,0 +1,10 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("waste_atlas", "0004_drop_file_base_from_map_configurations"),
+        ("waste_atlas", "0004_seed_residual_waste_composition_maps"),
+    ]
+
+    operations = []


### PR DESCRIPTION
## What changed

- adds an empty `waste_atlas` merge migration joining the two concurrently introduced `0004` branches
- updates the Rheinland-Pfalz map assertions to follow the centrally derived export filename contract merged in #319

## Why

Heroku release v944 built successfully but its release command stopped on Django's conflicting migration leaves:

- `0004_drop_file_base_from_map_configurations`
- `0004_seed_residual_waste_composition_maps`

The failed release never reached production; v943 remained active.

## Validation

- complete clean-database `python manage.py migrate --noinput` succeeded, including both `0004` nodes and the new `0005` merge
- 23 focused Waste Atlas tests passed
- `makemigrations --check --dry-run`
- Django system check
- Ruff check and format check
- `git diff --check`

Merging this PR should trigger the normal gated deployment flow again.