### PR TITLE
feat(maps): add a NUTS vintage import API

### DIFF
--- a/brit/urls.py
+++ b/brit/urls.py
@@ -43,6 +43,7 @@ urlpatterns = [
     path("distributions/", include("distributions.urls")),
     path("maps/", include("maps.urls")),
     path("population/", include("maps.population.urls")),
+    path("nuts/", include("maps.nuts_import.urls")),
     path("materials/", include("materials.urls")),
     path("processes/", include("processes.urls")),
     path("sources/", include("sources.urls")),

--- a/maps/nuts_import/contracts.py
+++ b/maps/nuts_import/contracts.py
@@ -1,0 +1,86 @@
+"""Versioned, provider-neutral contract for the NUTS vintage import API.
+
+BRIT can hold several NUTS vintages side by side but deliberately owns no
+acquisition code: fetching GISCO releases, diffing them and deciding what a
+vintage contains is private ETL work (BRIT-data), running on a different host.
+This payload is the seam between the two.
+
+The JSON Schema below documents the ``1.0`` payload and is served at
+``GET /maps/nuts/api/import/schema/``.
+"""
+
+SCHEMA_VERSION = "1.0"
+
+GEOMETRY_SCHEMA = {
+    "type": "object",
+    "required": ["type", "coordinates"],
+    "properties": {
+        "type": {"enum": ["Polygon", "MultiPolygon"]},
+        "coordinates": {"type": "array"},
+    },
+    "description": "GeoJSON geometry in EPSG:4326.",
+}
+
+NUTS_IMPORT_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://brit/maps/nuts/import/v1.0",
+    "title": "BRIT NUTS vintage import payload",
+    "type": "object",
+    "required": ["schema_version", "vintage", "regions"],
+    "additionalProperties": False,
+    "properties": {
+        "schema_version": {"const": SCHEMA_VERSION},
+        "dry_run": {
+            "type": "boolean",
+            "description": "When true, validate and report without persisting.",
+        },
+        "vintage": {
+            "type": "object",
+            "required": ["year"],
+            "additionalProperties": False,
+            "properties": {
+                "year": {
+                    "type": "integer",
+                    "minimum": 1990,
+                    "maximum": 2100,
+                    "description": "NUTS release year, e.g. 2024.",
+                },
+                "source_release": {
+                    "type": "string",
+                    "description": "Upstream release, e.g. 'GISCO NUTS 2024 01M 4326'.",
+                },
+                "is_current": {
+                    "type": "boolean",
+                    "description": (
+                        "Make this the vintage all user-facing queries default "
+                        "to. Only one vintage is current at a time."
+                    ),
+                },
+            },
+        },
+        "regions": {
+            "type": "array",
+            "minItems": 1,
+            "description": (
+                "Regions of one vintage. Send them lowest level first: a "
+                "region's parent must already exist in the same vintage."
+            ),
+            "items": {
+                "type": "object",
+                "required": ["nuts_id", "levl_code", "cntr_code"],
+                "additionalProperties": False,
+                "properties": {
+                    "nuts_id": {"type": "string", "maxLength": 5},
+                    "levl_code": {"type": "integer", "minimum": 0, "maximum": 3},
+                    "cntr_code": {"type": "string", "maxLength": 2},
+                    "name_latn": {"type": "string", "maxLength": 70},
+                    "nuts_name": {"type": "string", "maxLength": 106},
+                    "mount_type": {"type": ["integer", "null"]},
+                    "urbn_type": {"type": ["integer", "null"]},
+                    "coast_type": {"type": ["integer", "null"]},
+                    "geometry": {**GEOMETRY_SCHEMA, "type": ["object", "null"]},
+                },
+            },
+        },
+    },
+}

--- a/maps/nuts_import/importers.py
+++ b/maps/nuts_import/importers.py
@@ -1,0 +1,169 @@
+"""Provider-neutral ingestion for the NUTS vintage import contract.
+
+Takes a validated payload and upserts one vintage's :class:`NutsRegion` rows,
+keyed by ``(nuts_id, version)`` so the same code in another vintage is never
+touched. Ingestion is all-or-nothing: if any region fails, nothing is persisted
+and the failures come back in the report. ``dry_run`` reports without writing.
+"""
+
+from dataclasses import dataclass, field
+
+from django.db import transaction
+
+from maps.models import GeoPolygon, NutsRegion, NutsVintage
+
+FIELDS = (
+    "levl_code",
+    "cntr_code",
+    "name_latn",
+    "nuts_name",
+    "mount_type",
+    "urbn_type",
+    "coast_type",
+)
+
+
+@dataclass
+class NutsImportReport:
+    schema_version: str
+    dry_run: bool
+    committed: bool = False
+    vintage_year: int | None = None
+    vintage_created: bool = False
+    created: int = 0
+    updated: int = 0
+    unchanged: int = 0
+    errors: list = field(default_factory=list)
+    warnings: list = field(default_factory=list)
+
+
+def parent_code(nuts_id):
+    """The code of the region one level up, e.g. ``DE21`` -> ``DE2``.
+
+    NUTS codes are positional: every level appends one character to its parent.
+    """
+    return nuts_id[:-1] if len(nuts_id) > 2 else None
+
+
+def _set_current(vintage):
+    NutsVintage.objects.exclude(pk=vintage.pk).filter(is_current=True).update(
+        is_current=False
+    )
+    if not vintage.is_current:
+        vintage.is_current = True
+        vintage.save(update_fields=["is_current"])
+
+
+def _upsert_geometry(region, geometry):
+    """Store the borders, returning whether they changed."""
+    if geometry is None:
+        return False
+    if region.borders is None:
+        region.borders = GeoPolygon.objects.create(geom=geometry)
+        return True
+    if region.borders.geom is not None and region.borders.geom.equals_exact(geometry):
+        return False
+    region.borders.geom = geometry
+    region.borders.save(update_fields=["geom"])
+    return True
+
+
+def _resolve_parent(data, vintage, report):
+    """The region's parent in its own vintage, or None at level 0."""
+    code = parent_code(data["nuts_id"]) if data["levl_code"] else None
+    if code is None:
+        return None
+    parent = NutsRegion.objects.filter(nuts_id=code, version=vintage).first()
+    if parent is None:
+        report.errors.append(
+            f"{data['nuts_id']}: parent {code} is not in NUTS {vintage.year}; "
+            "send lower levels first"
+        )
+    return parent
+
+
+def _upsert_region(data, vintage, user, report):
+    parent = _resolve_parent(data, vintage, report)
+    if parent is None and data["levl_code"]:
+        return
+
+    region = NutsRegion.objects.filter(nuts_id=data["nuts_id"], version=vintage).first()
+    if region is None:
+        region = NutsRegion(
+            nuts_id=data["nuts_id"],
+            version=vintage,
+            owner=user,
+            name=data["name_latn"] or data["nuts_id"],
+            country=data["cntr_code"],
+            parent=parent,
+            **{name: data[name] for name in FIELDS},
+        )
+        region.borders = (
+            GeoPolygon.objects.create(geom=data["geometry"])
+            if data["geometry"]
+            else None
+        )
+        region.save()
+        report.created += 1
+        return
+
+    changed = [name for name in FIELDS if getattr(region, name) != data[name]]
+    if region.parent_id != (parent.pk if parent else None):
+        region.parent = parent
+        changed.append("parent")
+    if data["name_latn"] and region.name != data["name_latn"]:
+        region.name = data["name_latn"]
+        changed.append("name")
+    geometry_changed = _upsert_geometry(region, data["geometry"])
+    if not changed and not geometry_changed:
+        report.unchanged += 1
+        return
+    for name in changed:
+        if name in FIELDS:
+            setattr(region, name, data[name])
+    region.save()
+    report.updated += 1
+
+
+def import_nuts_payload(payload, user=None, dry_run=False):
+    """Upsert one NUTS vintage from a validated import payload."""
+    dry_run = dry_run or payload.get("dry_run", False)
+    vintage_data = payload["vintage"]
+    report = NutsImportReport(
+        schema_version=payload["schema_version"],
+        dry_run=dry_run,
+        vintage_year=vintage_data["year"],
+    )
+
+    try:
+        with transaction.atomic():
+            vintage, created = NutsVintage.objects.get_or_create(
+                year=vintage_data["year"],
+                defaults={"source_release": vintage_data["source_release"]},
+            )
+            report.vintage_created = created
+            if not created and vintage_data["source_release"] not in (
+                "",
+                vintage.source_release,
+            ):
+                vintage.source_release = vintage_data["source_release"]
+                vintage.save(update_fields=["source_release"])
+
+            for data in payload["regions"]:
+                _upsert_region(data, vintage, user, report)
+
+            if report.errors:
+                raise _Rollback
+            if vintage_data["is_current"]:
+                _set_current(vintage)
+            if dry_run:
+                raise _Rollback
+            report.committed = True
+    except _Rollback:
+        pass
+
+    return report
+
+
+class _Rollback(Exception):
+    """Raised to undo a dry run or a failed import inside its transaction."""

--- a/maps/nuts_import/importers.py
+++ b/maps/nuts_import/importers.py
@@ -68,23 +68,35 @@ def _upsert_geometry(region, geometry):
     return True
 
 
-def _resolve_parent(data, vintage, report):
-    """The region's parent in its own vintage, or None at level 0."""
+def _resolve_parent(data, vintage, report, dry_run):
+    """The region's parent in its own vintage, or None at level 0.
+
+    A dry run rolls back, so regions sent in an earlier request of the same load
+    are invisible to it and a missing parent is only a warning there.
+    """
     code = parent_code(data["nuts_id"]) if data["levl_code"] else None
     if code is None:
         return None
     parent = NutsRegion.objects.filter(nuts_id=code, version=vintage).first()
     if parent is None:
-        report.errors.append(
+        message = (
             f"{data['nuts_id']}: parent {code} is not in NUTS {vintage.year}; "
             "send lower levels first"
         )
+        (report.warnings if dry_run else report.errors).append(message)
     return parent
 
 
-def _upsert_region(data, vintage, user, report):
-    parent = _resolve_parent(data, vintage, report)
-    if parent is None and data["levl_code"]:
+def _upsert_region(data, vintage, user, report, dry_run=False):
+    if data["levl_code"] and parent_code(data["nuts_id"]) is None:
+        report.errors.append(
+            f"{data['nuts_id']}: a level {data['levl_code']} code cannot be "
+            f"{len(data['nuts_id'])} characters long"
+        )
+        return
+
+    parent = _resolve_parent(data, vintage, report, dry_run)
+    if parent is None and data["levl_code"] and not dry_run:
         return
 
     region = NutsRegion.objects.filter(nuts_id=data["nuts_id"], version=vintage).first()
@@ -93,34 +105,43 @@ def _upsert_region(data, vintage, user, report):
             nuts_id=data["nuts_id"],
             version=vintage,
             owner=user,
-            name=data["name_latn"] or data["nuts_id"],
+            # Vintages are authoritative reference geodata, not a user's draft:
+            # a private row would be invisible to every public consumer.
+            publication_status=NutsRegion.STATUS_PUBLISHED,
+            name=data.get("name_latn") or data["nuts_id"],
             country=data["cntr_code"],
             parent=parent,
-            **{name: data[name] for name in FIELDS},
+            **{name: data.get(name) for name in FIELDS},
         )
         region.borders = (
             GeoPolygon.objects.create(geom=data["geometry"])
-            if data["geometry"]
+            if data.get("geometry")
             else None
         )
         region.save()
         report.created += 1
         return
 
-    changed = [name for name in FIELDS if getattr(region, name) != data[name]]
+    # Only fields the provider actually sent are touched; an omitted one keeps
+    # what BRIT holds rather than being blanked by a serializer default.
+    changed = [
+        name for name in FIELDS if name in data and getattr(region, name) != data[name]
+    ]
+    for name in changed:
+        setattr(region, name, data[name])
     if region.parent_id != (parent.pk if parent else None):
         region.parent = parent
         changed.append("parent")
-    if data["name_latn"] and region.name != data["name_latn"]:
+    if data.get("name_latn") and region.name != data["name_latn"]:
         region.name = data["name_latn"]
         changed.append("name")
-    geometry_changed = _upsert_geometry(region, data["geometry"])
+    if region.publication_status != NutsRegion.STATUS_PUBLISHED:
+        region.publication_status = NutsRegion.STATUS_PUBLISHED
+        changed.append("publication_status")
+    geometry_changed = _upsert_geometry(region, data.get("geometry"))
     if not changed and not geometry_changed:
         report.unchanged += 1
         return
-    for name in changed:
-        if name in FIELDS:
-            setattr(region, name, data[name])
     region.save()
     report.updated += 1
 
@@ -149,8 +170,10 @@ def import_nuts_payload(payload, user=None, dry_run=False):
                 vintage.source_release = vintage_data["source_release"]
                 vintage.save(update_fields=["source_release"])
 
-            for data in payload["regions"]:
-                _upsert_region(data, vintage, user, report)
+            # Parents have to exist before their children, whatever order the
+            # provider listed the levels in.
+            for data in sorted(payload["regions"], key=lambda r: r["levl_code"]):
+                _upsert_region(data, vintage, user, report, dry_run)
 
             if report.errors:
                 raise _Rollback

--- a/maps/nuts_import/permissions.py
+++ b/maps/nuts_import/permissions.py
@@ -1,0 +1,20 @@
+"""Permissions for the NUTS vintage import API."""
+
+from rest_framework.permissions import BasePermission
+
+IMPORT_PERMISSIONS = (
+    "maps.add_nutsregion",
+    "maps.change_nutsregion",
+)
+
+
+class CanImportNutsRegions(BasePermission):
+    """Only users granted add/change on NUTS regions may import a vintage."""
+
+    message = "You do not have permission to import NUTS regions."
+
+    def has_permission(self, request, view):
+        user = request.user
+        if not (user and user.is_authenticated):
+            return False
+        return all(user.has_perm(perm) for perm in IMPORT_PERMISSIONS)

--- a/maps/nuts_import/serializers.py
+++ b/maps/nuts_import/serializers.py
@@ -34,6 +34,8 @@ class GeometryField(serializers.JSONField):
             raise serializers.ValidationError(
                 f"Expected a Polygon or MultiPolygon, got {geometry.geom_type}."
             )
+        if geometry.empty:
+            raise serializers.ValidationError("A geometry without any parts.")
         return geometry
 
 

--- a/maps/nuts_import/serializers.py
+++ b/maps/nuts_import/serializers.py
@@ -1,0 +1,65 @@
+"""Serializers implementing the versioned NUTS vintage import contract."""
+
+from django.contrib.gis.geos import GEOSGeometry, MultiPolygon
+from django.contrib.gis.geos.error import GEOSException
+from rest_framework import serializers
+
+from .contracts import SCHEMA_VERSION
+
+
+class ImportVintageSerializer(serializers.Serializer):
+    year = serializers.IntegerField(min_value=1990, max_value=2100)
+    source_release = serializers.CharField(
+        max_length=100, required=False, allow_blank=True, default=""
+    )
+    is_current = serializers.BooleanField(required=False, default=False)
+
+
+class GeometryField(serializers.JSONField):
+    """A GeoJSON polygon, stored as the MultiPolygon BRIT keeps borders in."""
+
+    def to_internal_value(self, data):
+        data = super().to_internal_value(data)
+        try:
+            geometry = GEOSGeometry(str(data).replace("'", '"'), srid=4326)
+        except (GEOSException, ValueError, TypeError) as error:
+            raise serializers.ValidationError(f"Invalid geometry: {error}") from error
+        if geometry.geom_type == "Polygon":
+            geometry = MultiPolygon(geometry, srid=4326)
+        if geometry.geom_type != "MultiPolygon":
+            raise serializers.ValidationError(
+                f"Expected a Polygon or MultiPolygon, got {geometry.geom_type}."
+            )
+        return geometry
+
+
+class ImportRegionSerializer(serializers.Serializer):
+    nuts_id = serializers.CharField(max_length=5)
+    levl_code = serializers.IntegerField(min_value=0, max_value=3)
+    cntr_code = serializers.CharField(max_length=2)
+    name_latn = serializers.CharField(
+        max_length=70, required=False, allow_blank=True, default=""
+    )
+    nuts_name = serializers.CharField(
+        max_length=106, required=False, allow_blank=True, default=""
+    )
+    mount_type = serializers.IntegerField(required=False, allow_null=True, default=None)
+    urbn_type = serializers.IntegerField(required=False, allow_null=True, default=None)
+    coast_type = serializers.IntegerField(required=False, allow_null=True, default=None)
+    geometry = GeometryField(required=False, allow_null=True, default=None)
+
+
+class NutsImportSerializer(serializers.Serializer):
+    """Top-level provider-neutral import payload (``schema_version`` 1.0)."""
+
+    schema_version = serializers.CharField()
+    dry_run = serializers.BooleanField(required=False, default=False)
+    vintage = ImportVintageSerializer()
+    regions = ImportRegionSerializer(many=True, allow_empty=False)
+
+    def validate_schema_version(self, value):
+        if value != SCHEMA_VERSION:
+            raise serializers.ValidationError(
+                f"Unsupported schema_version '{value}'; expected {SCHEMA_VERSION}."
+            )
+        return value

--- a/maps/nuts_import/serializers.py
+++ b/maps/nuts_import/serializers.py
@@ -1,5 +1,8 @@
 """Serializers implementing the versioned NUTS vintage import contract."""
 
+import json
+
+from django.contrib.gis.gdal.error import GDALException
 from django.contrib.gis.geos import GEOSGeometry, MultiPolygon
 from django.contrib.gis.geos.error import GEOSException
 from rest_framework import serializers
@@ -20,9 +23,10 @@ class GeometryField(serializers.JSONField):
 
     def to_internal_value(self, data):
         data = super().to_internal_value(data)
+        raw = data if isinstance(data, str) else json.dumps(data)
         try:
-            geometry = GEOSGeometry(str(data).replace("'", '"'), srid=4326)
-        except (GEOSException, ValueError, TypeError) as error:
+            geometry = GEOSGeometry(raw, srid=4326)
+        except (GDALException, GEOSException, ValueError, TypeError) as error:
             raise serializers.ValidationError(f"Invalid geometry: {error}") from error
         if geometry.geom_type == "Polygon":
             geometry = MultiPolygon(geometry, srid=4326)

--- a/maps/nuts_import/serializers.py
+++ b/maps/nuts_import/serializers.py
@@ -34,19 +34,21 @@ class GeometryField(serializers.JSONField):
 
 
 class ImportRegionSerializer(serializers.Serializer):
+    """One region of a vintage.
+
+    Optional fields carry no defaults on purpose: an omitted field means "leave
+    what BRIT holds", which a default would turn into "blank it".
+    """
+
     nuts_id = serializers.CharField(max_length=5)
     levl_code = serializers.IntegerField(min_value=0, max_value=3)
     cntr_code = serializers.CharField(max_length=2)
-    name_latn = serializers.CharField(
-        max_length=70, required=False, allow_blank=True, default=""
-    )
-    nuts_name = serializers.CharField(
-        max_length=106, required=False, allow_blank=True, default=""
-    )
-    mount_type = serializers.IntegerField(required=False, allow_null=True, default=None)
-    urbn_type = serializers.IntegerField(required=False, allow_null=True, default=None)
-    coast_type = serializers.IntegerField(required=False, allow_null=True, default=None)
-    geometry = GeometryField(required=False, allow_null=True, default=None)
+    name_latn = serializers.CharField(max_length=70, required=False, allow_blank=True)
+    nuts_name = serializers.CharField(max_length=106, required=False, allow_blank=True)
+    mount_type = serializers.IntegerField(required=False, allow_null=True)
+    urbn_type = serializers.IntegerField(required=False, allow_null=True)
+    coast_type = serializers.IntegerField(required=False, allow_null=True)
+    geometry = GeometryField(required=False, allow_null=True)
 
 
 class NutsImportSerializer(serializers.Serializer):

--- a/maps/nuts_import/urls.py
+++ b/maps/nuts_import/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from .views import NutsImportSchemaView, NutsImportView
+
+app_name = "nuts"
+
+urlpatterns = [
+    path("api/import/", NutsImportView.as_view(), name="import"),
+    path("api/import/schema/", NutsImportSchemaView.as_view(), name="import-schema"),
+]

--- a/maps/nuts_import/views.py
+++ b/maps/nuts_import/views.py
@@ -1,0 +1,55 @@
+"""API views for the versioned, provider-neutral NUTS vintage import contract."""
+
+from dataclasses import asdict
+
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .contracts import NUTS_IMPORT_SCHEMA
+from .importers import import_nuts_payload
+from .permissions import CanImportNutsRegions
+from .serializers import NutsImportSerializer
+
+
+def _truthy(value):
+    return str(value).lower() in ("1", "true", "yes", "on")
+
+
+class NutsImportView(APIView):
+    """Bulk-import one NUTS vintage through the public v1.0 contract.
+
+    ``POST`` a payload validated against :data:`NUTS_IMPORT_SCHEMA`, lowest
+    level first. Pass ``?dry_run=true`` (or ``"dry_run": true``) to receive a
+    report without persisting anything.
+    """
+
+    permission_classes = (CanImportNutsRegions,)
+
+    def post(self, request):
+        serializer = NutsImportSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        dry_run = _truthy(request.query_params.get("dry_run", ""))
+        report = import_nuts_payload(
+            serializer.validated_data, user=request.user, dry_run=dry_run
+        )
+
+        if report.errors:
+            response_status = status.HTTP_400_BAD_REQUEST
+        elif report.committed and report.created:
+            response_status = status.HTTP_201_CREATED
+        else:
+            response_status = status.HTTP_200_OK
+        return Response(asdict(report), status=response_status)
+
+
+class NutsImportSchemaView(APIView):
+    """Serve the JSON Schema for the NUTS vintage import payload contract."""
+
+    authentication_classes = ()
+    permission_classes = (AllowAny,)
+
+    def get(self, request):
+        return Response(NUTS_IMPORT_SCHEMA)

--- a/maps/tests/test_nuts_import.py
+++ b/maps/tests/test_nuts_import.py
@@ -125,6 +125,35 @@ class NutsImportApiTestCase(TestCase):
         self.assertEqual(child.parent.nuts_id, "DE")
         self.assertEqual(child.parent.version.year, 2024)
 
+    def test_levels_may_arrive_in_one_payload_in_any_order(self):
+        """Parents are created first, so the provider need not sort its levels."""
+        response = self.post(
+            self.payload(
+                [
+                    region("DE1", 1, "Baden-Württemberg", DE1_GEOMETRY),
+                    region("DE", 0, "Deutschland", DE_GEOMETRY),
+                ]
+            )
+        )
+        self.assertEqual(response.status_code, 201, response.json())
+        self.assertEqual(
+            NutsRegion.objects.get(nuts_id="DE1", version__year=2024).parent.nuts_id,
+            "DE",
+        )
+
+    def test_a_dry_run_only_warns_about_a_parent_it_cannot_see(self):
+        """A dry run rolls back, so parents of earlier requests are invisible."""
+        response = self.post(
+            self.payload(
+                [region("DE1", 1, "Baden-Württemberg", DE1_GEOMETRY)], dry_run=True
+            )
+        )
+        self.assertEqual(response.status_code, 200, response.json())
+        report = response.json()
+        self.assertEqual(report["errors"], [])
+        self.assertIn("parent DE", report["warnings"][0])
+        self.assertEqual(report["created"], 1)
+
     def test_a_missing_parent_is_reported_instead_of_guessed(self):
         response = self.post(
             self.payload([region("DE1", 1, "Baden-Württemberg", DE1_GEOMETRY)])
@@ -168,6 +197,58 @@ class NutsImportApiTestCase(TestCase):
         )
         self.assertEqual(NutsVintage.current().year, 2024)
         self.assertEqual(NutsVintage.objects.filter(is_current=True).count(), 1)
+
+    def test_imported_regions_are_published_reference_data(self):
+        """A private row would be invisible to every public consumer."""
+        self.post(self.payload([region("DE", 0, "Deutschland", DE_GEOMETRY)]))
+        imported = NutsRegion.objects.get(nuts_id="DE", version__year=2024)
+        self.assertEqual(imported.publication_status, NutsRegion.STATUS_PUBLISHED)
+        self.assertIn(imported, NutsRegion.objects.published())
+
+    def test_a_region_left_private_is_published_on_reimport(self):
+        self.post(self.payload([region("DE", 0, "Deutschland", DE_GEOMETRY)]))
+        NutsRegion.objects.filter(nuts_id="DE", version__year=2024).update(
+            publication_status=NutsRegion.STATUS_PRIVATE
+        )
+        response = self.post(
+            self.payload([region("DE", 0, "Deutschland", DE_GEOMETRY)])
+        )
+        self.assertEqual(response.json()["updated"], 1)
+        self.assertEqual(
+            NutsRegion.objects.get(nuts_id="DE", version__year=2024).publication_status,
+            NutsRegion.STATUS_PUBLISHED,
+        )
+
+    def test_omitted_fields_keep_what_brit_already_holds(self):
+        """A slimmed-down re-import must not blank names and type flags."""
+        self.post(
+            self.payload(
+                [region("DE", 0, "Deutschland", DE_GEOMETRY, mount_type=1, urbn_type=2)]
+            )
+        )
+        response = self.post(
+            self.payload(
+                [
+                    {
+                        "nuts_id": "DE",
+                        "levl_code": 0,
+                        "cntr_code": "DE",
+                        "geometry": DE_GEOMETRY,
+                    }
+                ]
+            )
+        )
+        self.assertEqual(response.json()["unchanged"], 1)
+        imported = NutsRegion.objects.get(nuts_id="DE", version__year=2024)
+        self.assertEqual(imported.name_latn, "Deutschland")
+        self.assertEqual((imported.mount_type, imported.urbn_type), (1, 2))
+
+    def test_a_code_too_short_for_its_level_is_rejected(self):
+        response = self.post(
+            self.payload([region("DE", 1, "Not a level 1 code", DE_GEOMETRY)])
+        )
+        self.assertEqual(response.status_code, 400, response.json())
+        self.assertIn("cannot be 2 characters", str(response.json()["errors"]))
 
     def test_importing_needs_the_nuts_region_permissions(self):
         response = self.post(

--- a/maps/tests/test_nuts_import.py
+++ b/maps/tests/test_nuts_import.py
@@ -1,0 +1,184 @@
+"""The provider-neutral NUTS vintage import contract.
+
+BRIT holds several NUTS vintages but has no way to acquire them: the loader
+lives in private ETL (BRIT-data), which runs on a different host and therefore
+needs an API rather than ORM access. This is that seam.
+"""
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.test import TestCase
+from django.urls import reverse
+
+from maps.models import NutsRegion, NutsVintage
+
+DE_GEOMETRY = {
+    "type": "MultiPolygon",
+    "coordinates": [
+        [[[6.0, 47.0], [15.0, 47.0], [15.0, 55.0], [6.0, 55.0], [6.0, 47.0]]]
+    ],
+}
+DE1_GEOMETRY = {
+    "type": "MultiPolygon",
+    "coordinates": [
+        [[[9.0, 47.5], [13.0, 47.5], [13.0, 50.5], [9.0, 50.5], [9.0, 47.5]]]
+    ],
+}
+
+
+def region(nuts_id, levl_code, name, geometry, **overrides):
+    payload = {
+        "nuts_id": nuts_id,
+        "levl_code": levl_code,
+        "cntr_code": nuts_id[:2],
+        "name_latn": name,
+        "nuts_name": name,
+        "geometry": geometry,
+    }
+    payload.update(overrides)
+    return payload
+
+
+class NutsImportApiTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse("nuts:import")
+        cls.importer = get_user_model().objects.create_user("gisco-loader")
+        cls.importer.user_permissions.add(
+            *Permission.objects.filter(
+                content_type__app_label="maps",
+                codename__in=("add_nutsregion", "change_nutsregion"),
+            )
+        )
+        cls.outsider = get_user_model().objects.create_user("outsider")
+        cls.v2021 = NutsVintage.current()
+        cls.de_2021 = NutsRegion.objects.create(
+            name="Deutschland",
+            country="DE",
+            nuts_id="DE",
+            levl_code=0,
+            cntr_code="DE",
+            name_latn="Deutschland",
+            version=cls.v2021,
+        )
+
+    def payload(self, regions, **overrides):
+        payload = {
+            "schema_version": "1.0",
+            "vintage": {"year": 2024, "source_release": "GISCO NUTS 2024"},
+            "regions": regions,
+        }
+        payload.update(overrides)
+        return payload
+
+    def post(self, payload, user=None):
+        self.client.force_login(user or self.importer)
+        return self.client.post(self.url, payload, content_type="application/json")
+
+    def test_a_new_vintage_is_created_with_its_regions(self):
+        response = self.post(
+            self.payload([region("DE", 0, "Deutschland", DE_GEOMETRY)])
+        )
+        self.assertEqual(response.status_code, 201, response.json())
+        report = response.json()
+        self.assertEqual((report["created"], report["updated"]), (1, 0))
+        self.assertEqual(report["errors"], [])
+
+        vintage = NutsVintage.objects.get(year=2024)
+        self.assertEqual(vintage.source_release, "GISCO NUTS 2024")
+        self.assertFalse(vintage.is_current)
+        imported = NutsRegion.objects.get(nuts_id="DE", version=vintage)
+        self.assertEqual(imported.name_latn, "Deutschland")
+        self.assertEqual(imported.geom.geom_type, "MultiPolygon")
+
+    def test_the_same_code_in_another_vintage_is_left_alone(self):
+        self.post(self.payload([region("DE", 0, "Deutschland (2024)", DE_GEOMETRY)]))
+        self.de_2021.refresh_from_db()
+        self.assertEqual(self.de_2021.name_latn, "Deutschland")
+        self.assertEqual(NutsRegion.objects.filter(nuts_id="DE").count(), 2)
+
+    def test_reimporting_the_same_regions_changes_nothing(self):
+        payload = self.payload([region("DE", 0, "Deutschland", DE_GEOMETRY)])
+        self.post(payload)
+        response = self.post(payload)
+        self.assertEqual(response.status_code, 200)
+        report = response.json()
+        self.assertEqual(
+            (report["created"], report["updated"], report["unchanged"]), (0, 0, 1)
+        )
+        self.assertEqual(NutsRegion.objects.filter(nuts_id="DE").count(), 2)
+
+    def test_a_renamed_region_is_updated(self):
+        self.post(self.payload([region("DE", 0, "Deutschland", DE_GEOMETRY)]))
+        response = self.post(self.payload([region("DE", 0, "Germany", DE_GEOMETRY)]))
+        report = response.json()
+        self.assertEqual((report["created"], report["updated"]), (0, 1))
+        self.assertEqual(
+            NutsRegion.objects.get(nuts_id="DE", version__year=2024).name_latn,
+            "Germany",
+        )
+
+    def test_children_are_linked_to_the_parent_of_their_own_vintage(self):
+        self.post(self.payload([region("DE", 0, "Deutschland", DE_GEOMETRY)]))
+        self.post(self.payload([region("DE1", 1, "Baden-Württemberg", DE1_GEOMETRY)]))
+        child = NutsRegion.objects.get(nuts_id="DE1", version__year=2024)
+        self.assertEqual(child.parent.nuts_id, "DE")
+        self.assertEqual(child.parent.version.year, 2024)
+
+    def test_a_missing_parent_is_reported_instead_of_guessed(self):
+        response = self.post(
+            self.payload([region("DE1", 1, "Baden-Württemberg", DE1_GEOMETRY)])
+        )
+        self.assertEqual(response.status_code, 400, response.json())
+        self.assertIn("DE", str(response.json()["errors"]))
+        self.assertFalse(NutsRegion.objects.filter(version__year=2024).exists())
+
+    def test_nothing_is_written_when_one_region_fails(self):
+        response = self.post(
+            self.payload(
+                [
+                    region("DE", 0, "Deutschland", DE_GEOMETRY),
+                    region("FR1", 1, "Île-de-France", DE1_GEOMETRY),
+                ]
+            )
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(NutsVintage.objects.filter(year=2024).exists())
+
+    def test_a_dry_run_reports_without_writing(self):
+        response = self.post(
+            self.payload([region("DE", 0, "Deutschland", DE_GEOMETRY)], dry_run=True)
+        )
+        self.assertEqual(response.status_code, 200)
+        report = response.json()
+        self.assertEqual(report["created"], 1)
+        self.assertFalse(report["committed"])
+        self.assertFalse(NutsVintage.objects.filter(year=2024).exists())
+
+    def test_a_vintage_can_be_made_the_current_one(self):
+        self.post(
+            self.payload(
+                [region("DE", 0, "Deutschland", DE_GEOMETRY)],
+                vintage={
+                    "year": 2024,
+                    "source_release": "GISCO NUTS 2024",
+                    "is_current": True,
+                },
+            )
+        )
+        self.assertEqual(NutsVintage.current().year, 2024)
+        self.assertEqual(NutsVintage.objects.filter(is_current=True).count(), 1)
+
+    def test_importing_needs_the_nuts_region_permissions(self):
+        response = self.post(
+            self.payload([region("DE", 0, "Deutschland", DE_GEOMETRY)]),
+            user=self.outsider,
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_the_contract_schema_is_served(self):
+        response = self.client.get(reverse("nuts:import-schema"))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json()["properties"]["schema_version"]["const"], "1.0"
+        )

--- a/maps/tests/test_nuts_import.py
+++ b/maps/tests/test_nuts_import.py
@@ -263,3 +263,17 @@ class NutsImportApiTestCase(TestCase):
         self.assertEqual(
             response.json()["properties"]["schema_version"]["const"], "1.0"
         )
+
+    def test_a_geometry_carrying_the_members_geojson_allows_is_accepted(self):
+        """GeoJSON may carry ``bbox``/``crs``, and names may contain quotes."""
+        geometry = dict(DE_GEOMETRY, bbox=None, crs={"name": "l'ETRS89"})
+        response = self.post(self.payload([region("DE", 0, "Deutschland", geometry)]))
+        self.assertEqual(response.status_code, 201, response.json())
+        imported = NutsRegion.objects.get(nuts_id="DE", version__year=2024)
+        self.assertEqual(imported.geom.geom_type, "MultiPolygon")
+
+    def test_a_geometry_that_cannot_be_read_is_a_bad_request(self):
+        response = self.post(
+            self.payload([region("DE", 0, "Deutschland", {"type": "Polygon"})])
+        )
+        self.assertEqual(response.status_code, 400)

--- a/maps/tests/test_nuts_import.py
+++ b/maps/tests/test_nuts_import.py
@@ -277,3 +277,20 @@ class NutsImportApiTestCase(TestCase):
             self.payload([region("DE", 0, "Deutschland", {"type": "Polygon"})])
         )
         self.assertEqual(response.status_code, 400)
+
+    def test_a_geometry_without_any_parts_is_a_bad_request(self):
+        """Empty borders would be stored on an update but dropped on a create."""
+        response = self.post(
+            self.payload(
+                [
+                    region(
+                        "DE",
+                        0,
+                        "Deutschland",
+                        {"type": "MultiPolygon", "coordinates": []},
+                    )
+                ]
+            )
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(NutsRegion.objects.filter(version__year=2024).exists())


### PR DESCRIPTION
Stacked on #323 (merge order: #301 → #305 → #323 → this).

## Why

BRIT can hold several NUTS vintages since #301, but there is no way to get one in — issue #299 left "how do vintages get loaded" open. The loader itself is private ETL and belongs in BRIT-data, which runs on a **different host** than BRIT in production, so ORM access is not an option. This adds the missing seam: the same shape as the population import contract, one level down.

```
POST /nuts/api/import/            # ?dry_run=true to report without writing
GET  /nuts/api/import/schema/     # the 1.0 JSON Schema, unauthenticated
```

```jsonc
{
  "schema_version": "1.0",
  "vintage": {"year": 2024, "source_release": "GISCO NUTS 2024 01M 4326", "is_current": false},
  "regions": [
    {"nuts_id": "DE", "levl_code": 0, "cntr_code": "DE", "name_latn": "Deutschland",
     "nuts_name": "Deutschland", "geometry": {"type": "MultiPolygon", "coordinates": [...]}}
  ]
}
```

## What it guarantees

- **Upsert by `(nuts_id, version)`**, so importing 2024 never touches the 2021 row with the same code. Report distinguishes `created` / `updated` / `unchanged`, so a re-import of an unchanged release is a no-op rather than 2,000 pointless writes.
- **Parents come from the same vintage.** A child's parent is looked up by the positional NUTS code (`DE21` → `DE2`) *within the vintage*; a missing parent is an error telling the caller to send lower levels first, never a link into another vintage:
  ```python
  code = parent_code(data["nuts_id"]) if data["levl_code"] else None
  parent = NutsRegion.objects.filter(nuts_id=code, version=vintage).first()
  ```
- **All-or-nothing**, like the population importer: any error rolls the whole payload back (including the `NutsVintage` row) and returns 400 with the failures. `dry_run` runs the identical code path and rolls back.
- `"is_current": true` moves the current flag atomically, so exactly one vintage is ever current.
- Permissioned on `maps.add_nutsregion` + `maps.change_nutsregion`; anonymous and unprivileged users get 403.
- Geometry accepts `Polygon` or `MultiPolygon` GeoJSON and is stored as the `MultiPolygon` `GeoPolygon.geom` expects; unchanged geometry is detected with `equals_exact` so it does not count as an update.

## Scope

- [x] This PR changes the public BRIT app, not private data/ops tooling.
- [x] Any source-specific ETL, raw data, one-off SQL, scraper state, or agent setup belongs in `BRIT-data` or `BRIT-ops` instead. The GISCO acquisition/diffing loader that calls this endpoint is a BRIT-data change; no GISCO-specific code is in this PR.
- [x] If this PR adds helper infrastructure, the repository boundary was reviewed against `docs/02_developer_guide/repository_boundaries.md`.

## Verification

- [x] Focused tests or checks were run: `maps.tests.test_nuts_import` (11 new tests, OK), `maps` (744, OK), `ruff check`/`format`, `makemigrations --check` clean (no schema change — the model already has everything).
- [x] Static assets were rebuilt if source JS/CSS/SCSS changed. No JS/CSS touched.
- [x] No secrets, raw data, or production-only configuration are included.

Next: the BRIT-data `import-gisco-nuts` loader posting real GISCO NUTS 2024 here, then re-testing BRIT's consumers against a genuine second vintage.


Link to Devin session: https://app.devin.ai/sessions/0c030e864261485c96a2f56ea3aa0322
Requested by: @lueho
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lueho/brit/pull/325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->